### PR TITLE
Add OAuth authentication, Rate and Swap API services

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+    "mcpServers": {
+        "BlaaizAPIDocs": {
+            "type": "http",
+            "url": "https://docs.business.blaaiz.com/mcp"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blaaiz Laravel SDK
 
-A comprehensive Laravel SDK for the Blaaiz RaaS (Remittance as a Service) API. This SDK provides easy-to-use methods for payment processing, collections, payouts, customer management, and more.
+Official Laravel SDK for the Blaaiz RaaS (Remittance as a Service) API.
 
 ## Installation
 
@@ -8,940 +8,70 @@ A comprehensive Laravel SDK for the Blaaiz RaaS (Remittance as a Service) API. T
 composer require blaaiz/blaaiz-laravel-sdk
 ```
 
+Laravel package discovery is enabled automatically.
+
 ## Quick Start
 
-### Authentication
+### OAuth 2.0
 
-The SDK supports two authentication methods. **OAuth 2.0 is recommended** for new integrations.
+OAuth is recommended for new integrations.
 
-**Option 1: OAuth 2.0 (Recommended)**
 ```env
 BLAAIZ_CLIENT_ID=your-client-id
 BLAAIZ_CLIENT_SECRET=your-client-secret
 BLAAIZ_API_URL=https://api-dev.blaaiz.com
 ```
 
-**Option 2: Legacy API Key**
-```env
-BLAAIZ_API_KEY=your-api-key-here
-BLAAIZ_API_URL=https://api-dev.blaaiz.com
-```
-
-When both OAuth credentials and an API key are configured, OAuth takes priority.
-
 ```php
-// Publish configuration (optional)
-php artisan vendor:publish --tag=blaaiz-config
-
-// Test the connection
 use Blaaiz\LaravelSdk\Facades\Blaaiz;
 
 $isConnected = Blaaiz::testConnection();
-echo $isConnected ? 'API Connected' : 'Connection Failed';
-```
-
-## Features
-
-- **Customer Management**: Create, update, and manage customers with KYC verification
-- **Collections**: Support for multiple collection methods (Open Banking, Card, Crypto, Bank Transfer)
-- **Payouts**: Bank transfers and Interac payouts across multiple currencies
-- **Virtual Bank Accounts**: Create and manage virtual accounts for NGN collections
-- **Wallets**: Multi-currency wallet management
-- **Transactions**: Transaction history and status tracking
-- **Webhooks**: Webhook configuration and management with signature verification
-- **Files**: Document upload with pre-signed URLs
-- **Fees**: Real-time fee calculations and breakdowns
-- **Banks & Currencies**: Access to supported banks and currencies
-- **Rates**: View exchange rates with optional currency pair filtering
-- **Swap**: Swap money between business wallets
-- **OAuth 2.0 Authentication**: Client credentials flow with automatic token management
-- **Laravel Integration**: Native service provider, facade, and configuration
-
-## Supported Currencies & Methods
-
-### Collections
-- **CAD**: Interac (push mechanism)
-- **NGN**: Bank Transfer (VBA) and Card Payment
-- **USD**: Card Payment
-- **EUR/GBP**: Open Banking
-
-### Payouts
-- **Bank Transfer**: NGN, GBP, EUR
-- **Interac**: CAD transactions
-- **ACH**: USD transactions
-- **Wire**: USD transactions
-- **Crypto**: USDT, USDC on multiple networks
-
-## API Reference
-
-### Customer Management
-
-#### Create a Customer
-
-```php
-use Blaaiz\LaravelSdk\Facades\Blaaiz;
-
-$customer = Blaaiz::customers()->create([
-    'first_name' => 'John',
-    'last_name' => 'Doe',
-    'type' => 'individual', // or 'business'
-    'email' => 'john.doe@example.com',
-    'country' => 'NG',
-    'id_type' => 'passport', // drivers_license, passport, id_card, resident_permit
-    'id_number' => 'A12345678',
-    // 'business_name' => 'Company Name' // Required if type is 'business'
-]);
-
-echo 'Customer ID: ' . $customer['data']['data']['id'];
-```
-
-#### Get Customer
-
-```php
-$customer = Blaaiz::customers()->get('customer-id');
-echo 'Customer: ' . json_encode($customer['data']);
-```
-
-#### List All Customers
-
-```php
-$customers = Blaaiz::customers()->list();
-echo 'Customers: ' . json_encode($customers['data']);
-```
-
-#### Update Customer
-
-```php
-$updatedCustomer = Blaaiz::customers()->update('customer-id', [
-    'first_name' => 'Jane',
-    'email' => 'jane.doe@example.com'
-]);
-```
-
-#### List Customer Beneficiaries
-
-```php
-$beneficiaries = Blaaiz::customers()->listBeneficiaries('customer-id');
-echo 'Beneficiaries: ' . json_encode($beneficiaries['data']);
-```
-
-#### Get Specific Beneficiary
-
-```php
-$beneficiary = Blaaiz::customers()->getBeneficiary('customer-id', 'beneficiary-id');
-echo 'Beneficiary: ' . json_encode($beneficiary['data']);
-```
-
-### File Management & KYC
-
-#### Upload Customer Documents
-
-**Method 1: Complete File Upload (Recommended)**
-```php
-// Option A: Upload from file path
-$result = Blaaiz::customers()->uploadFileComplete('customer-id', [
-    'file' => file_get_contents('/path/to/passport.jpg'),
-    'file_category' => 'identity', // identity, proof_of_address, liveness_check
-    'filename' => 'passport.jpg', // Optional
-    'content_type' => 'image/jpeg' // Optional
-]);
-
-// Option B: Upload from Base64 string
-$result = Blaaiz::customers()->uploadFileComplete('customer-id', [
-    'file' => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-    'file_category' => 'identity'
-]);
-
-// Option C: Upload from Data URL (with automatic content type detection)
-$result = Blaaiz::customers()->uploadFileComplete('customer-id', [
-    'file' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-    'file_category' => 'identity'
-]);
-
-// Option D: Upload from Public URL (automatically downloads and uploads)
-$result = Blaaiz::customers()->uploadFileComplete('customer-id', [
-    'file' => 'https://example.com/documents/passport.jpg',
-    'file_category' => 'identity'
-]);
-
-echo 'Upload complete: ' . json_encode($result['data']);
-echo 'File ID: ' . $result['file_id'];
-```
-
-**Method 2: Manual 3-Step Process**
-```php
-// Step 1: Get pre-signed URL
-$presignedUrl = Blaaiz::files()->getPresignedUrl([
-    'customer_id' => 'customer-id',
-    'file_category' => 'identity' // identity, proof_of_address, liveness_check
-]);
-
-// Step 2: Upload file to the pre-signed URL (implement your file upload logic)
-// Use Guzzle or any HTTP client to upload the file
-
-// Step 3: Associate file with customer
-$fileAssociation = Blaaiz::customers()->uploadFiles('customer-id', [
-    'id_file' => $presignedUrl['data']['file_id'] // Use the file_id from step 1
-]);
-```
-
-> **Note**: The `uploadFileComplete` method is recommended as it handles all three steps automatically: getting the pre-signed URL, uploading the file to S3, and associating the file with the customer. It supports multiple file input formats:
-> - **String path/content**: Direct binary data or file path
-> - **Base64 string**: Plain base64 encoded data
-> - **Data URL**: Complete data URL with mime type (e.g., `data:image/jpeg;base64,/9j/4AAQ...`)
-> - **Public URL**: HTTP/HTTPS URL that will be downloaded automatically (supports redirects, content-type detection, and filename extraction)
-
-### Collections
-
-#### Initiate Open Banking Collection (EUR/GBP)
-
-```php
-$collection = Blaaiz::collections()->initiate([
-    'customer_id' => 'customer-id',
-    'wallet_id' => 'wallet-id',
-    'amount' => 100.00,
-    'currency' => 'EUR', // EUR, GBP, NGN, USD
-    'method' => 'open_banking',
-    'phone_number' => '+1234567890', // Optional
-    'email' => 'customer@example.com', // Optional
-    'reference' => 'your-reference', // Optional
-    'narration' => 'Payment description', // Optional
-    'redirect_url' => 'https://your-site.com/callback' // Optional
-]);
-
-echo 'Payment URL: ' . $collection['data']['url'];
-echo 'Transaction ID: ' . $collection['data']['transaction_id'];
-```
-
-#### Initiate Card Collection (NGN/USD)
-
-```php
-$collection = Blaaiz::collections()->initiate([
-    'customer_id' => 'customer-id',
-    'wallet_id' => 'wallet-id',
-    'amount' => 5000,
-    'currency' => 'NGN',
-    'method' => 'card'
-]);
-
-echo 'Payment URL: ' . $collection['data']['url'];
-```
-
-#### Accept Interac Money Request (CAD)
-
-```php
-// With security answer (standard transfer)
-$interac = Blaaiz::collections()->acceptInteracMoneyRequest([
-    'reference_number' => 'interac-reference',
-    'security_answer' => 'answer',
-    'email' => 'sender@example.com' // Optional
-]);
-
-// Auto deposit (no security answer required)
-$interacAutoDeposit = Blaaiz::collections()->acceptInteracMoneyRequest([
-    'reference_number' => 'interac-reference'
-]);
-
-echo 'Message: ' . $interac['data']['message'];
-```
-
-#### Crypto Collection
-
-```php
-// Get available networks
-$networks = Blaaiz::collections()->getCryptoNetworks();
-echo 'Available networks: ' . json_encode($networks['data']);
-
-// Initiate crypto collection
-$cryptoCollection = Blaaiz::collections()->initiateCrypto([
-    'amount' => 100,
-    'network' => 'ethereum',
-    'token' => 'USDT',
-    'wallet_id' => 'wallet-id'
-]);
-```
-
-#### Attach Customer to Collection
-
-```php
-$attachment = Blaaiz::collections()->attachCustomer([
-    'customer_id' => 'customer-id',
-    'transaction_id' => 'transaction-id'
-]);
-```
-
-### Payouts
-
-#### Bank Transfer Payout (NGN)
-
-```php
-$payout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'bank_transfer',
-    'from_amount' => 1000, // Use from_amount OR to_amount
-    'from_currency_id' => 'NGN',
-    'to_currency_id' => 'NGN',
-    'bank_id' => 'bank-id', // Required for NGN
-    'account_number' => '0123456789',
-    'phone_number' => '+2348012345678' // Optional
-]);
-
-echo 'Payout Status: ' . $payout['data']['transaction']['status'];
-```
-
-#### Bank Transfer Payout (GBP)
-
-```php
-$gbpPayout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'bank_transfer',
-    'from_amount' => 100,
-    'from_currency_id' => 'GBP',
-    'to_currency_id' => 'GBP',
-    'sort_code' => '123456',
-    'account_number' => '12345678',
-    'account_name' => 'John Doe'
-]);
-```
-
-#### Bank Transfer Payout (EUR)
-
-```php
-$eurPayout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'bank_transfer',
-    'from_amount' => 100,
-    'from_currency_id' => 'EUR',
-    'to_currency_id' => 'EUR',
-    'iban' => 'DE89370400440532013000',
-    'bic_code' => 'COBADEFFXXX',
-    'account_name' => 'John Doe'
-]);
-```
-
-#### Interac Payout (CAD)
-
-```php
-$interacPayout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'interac',
-    'from_amount' => 100,
-    'from_currency_id' => 'CAD',
-    'to_currency_id' => 'CAD',
-    'email' => 'recipient@example.com',
-    'interac_first_name' => 'John',
-    'interac_last_name' => 'Doe'
-]);
-```
-
-#### ACH Payout (USD)
-
-```php
-$achPayout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'ach',
-    'from_amount' => 100,
-    'from_currency_id' => 'USD',
-    'to_currency_id' => 'USD',
-    'type' => 'individual', // individual or business
-    'account_number' => '123456789',
-    'account_name' => 'John Doe',
-    'account_type' => 'checking', // checking or savings
-    'bank_name' => 'Chase Bank',
-    'routing_number' => '021000021'
-]);
-```
-
-#### Wire Payout (USD)
-
-```php
-$wirePayout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'wire',
-    'from_amount' => 1000,
-    'from_currency_id' => 'USD',
-    'to_currency_id' => 'USD',
-    'type' => 'individual',
-    'account_number' => '123456789',
-    'account_name' => 'John Doe',
-    'account_type' => 'checking',
-    'bank_name' => 'Chase Bank',
-    'routing_number' => '021000021',
-    'swift_code' => 'CHASUS33'
-]);
-```
-
-#### Crypto Payout
-
-```php
-$cryptoPayout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'crypto',
-    'from_amount' => 100,
-    'from_currency_id' => 'USD',
-    'to_currency_id' => 'USDT',
-    'wallet_address' => '0x1234567890abcdef...',
-    'wallet_token' => 'USDT', // USDT or USDC
-    'wallet_network' => 'ETHEREUM_MAINNET' // BSC_MAINNET, ETHEREUM_MAINNET, TRON_MAINNET, MATIC_MAINNET
-]);
-```
-
-#### Using to_amount Instead of from_amount
-
-You can specify the exact amount the recipient should receive:
-
-```php
-$payout = Blaaiz::payouts()->initiate([
-    'wallet_id' => 'wallet-id',
-    'customer_id' => 'customer-id',
-    'method' => 'bank_transfer',
-    'to_amount' => 50000, // Recipient gets exactly this amount
-    'from_currency_id' => 'USD',
-    'to_currency_id' => 'NGN',
-    'bank_id' => 'bank-id',
-    'account_number' => '0123456789'
-]);
-```
-
-### Virtual Bank Accounts
-
-#### Create Virtual Bank Account
-
-```php
-$vba = Blaaiz::virtualBankAccounts()->create([
-    'wallet_id' => 'wallet-id',
-    'account_name' => 'John Doe'
-]);
-
-echo 'Account Number: ' . $vba['data']['account_number'];
-echo 'Bank Name: ' . $vba['data']['bank_name'];
-```
-
-#### List Virtual Bank Accounts
-
-You can optionally filter by `wallet_id`, `customer_id`, or both.
-
-```php
-// All virtual bank accounts
-$vbas = Blaaiz::virtualBankAccounts()->list();
-
-// Filter by wallet
-$vbasByWallet = Blaaiz::virtualBankAccounts()->list('wallet-id');
-
-// Filter by customer
-$vbasByCustomer = Blaaiz::virtualBankAccounts()->list(null, 'customer-id');
-
-// Filter by both wallet and customer
-$vbasByBoth = Blaaiz::virtualBankAccounts()->list('wallet-id', 'customer-id');
-
-echo 'All: ' . json_encode($vbas['data']);
-echo 'By Wallet: ' . json_encode($vbasByWallet['data']);
-echo 'By Customer: ' . json_encode($vbasByCustomer['data']);
-echo 'By Both: ' . json_encode($vbasByBoth['data']);
-```
-
-#### Close Virtual Bank Account
-
-```php
-// Close without reason
-$closed = Blaaiz::virtualBankAccounts()->close('vba-id');
-
-// Close with reason
-$closed = Blaaiz::virtualBankAccounts()->close('vba-id', 'No longer needed');
-
-echo 'Status: ' . $closed['data']['status'];
-```
-
-#### Get Identification Type
-
-Retrieve the expected identification type label based on country and customer type. This is useful for determining what identification documents are required for a customer.
-
-```php
-// Using customer_id (recommended if customer already exists)
-$idType = Blaaiz::virtualBankAccounts()->getIdentificationType('customer-id');
-echo 'Required ID: ' . $idType['data']['label']; // e.g., "Bank Verification Number"
-echo 'Type: ' . $idType['data']['type']; // e.g., "bvn"
-
-// Using country and type (for new customers)
-$idType = Blaaiz::virtualBankAccounts()->getIdentificationType(null, 'NG', 'individual');
-echo 'Required ID: ' . $idType['data']['label'];
-```
-
-### Wallets
-
-#### List All Wallets
-
-```php
-$wallets = Blaaiz::wallets()->list();
-echo 'Wallets: ' . json_encode($wallets['data']);
-```
-
-#### Get Specific Wallet
-
-```php
-$wallet = Blaaiz::wallets()->get('wallet-id');
-echo 'Wallet Balance: ' . $wallet['data']['balance'];
-```
-
-### Transactions
-
-#### List Transactions
-
-```php
-$transactions = Blaaiz::transactions()->list([
-    'page' => 1,
-    'limit' => 10,
-    'status' => 'SUCCESSFUL' // Optional filter
-]);
-
-echo 'Transactions: ' . json_encode($transactions['data']);
-```
-
-#### Get Transaction Details
-
-```php
-$transaction = Blaaiz::transactions()->get('transaction-id');
-echo 'Transaction: ' . json_encode($transaction['data']);
-```
-
-### Banks & Currencies
-
-#### List Banks
-
-```php
-$banks = Blaaiz::banks()->list();
-echo 'Available Banks: ' . json_encode($banks['data']);
-```
-
-#### Bank Account Lookup
-
-```php
-$accountInfo = Blaaiz::banks()->lookupAccount([
-    'account_number' => '0123456789',
-    'bank_id' => '1'
-]);
-
-echo 'Account Name: ' . $accountInfo['data']['account_name'];
-```
-
-#### List Currencies
-
-```php
 $currencies = Blaaiz::currencies()->list();
-echo 'Supported Currencies: ' . json_encode($currencies['data']);
 ```
 
-### Fees
+### Legacy API key
 
-#### Get Fee Breakdown
-
-```php
-// Using from_amount (calculate what recipient gets)
-$feeBreakdown = Blaaiz::fees()->getBreakdown([
-    'from_currency_id' => 'NGN',
-    'to_currency_id' => 'CAD',
-    'from_amount' => 100000
-]);
-
-echo 'You send: ' . $feeBreakdown['data']['you_send'];
-echo 'Recipient gets: ' . $feeBreakdown['data']['recipient_gets'];
-echo 'Total fees: ' . $feeBreakdown['data']['total_fees'];
-
-// Using to_amount (calculate what you need to send)
-$feeBreakdown = Blaaiz::fees()->getBreakdown([
-    'from_currency_id' => 'USD',
-    'to_currency_id' => 'NGN',
-    'to_amount' => 50000 // Recipient should get exactly this
-]);
-
-echo 'You send: ' . $feeBreakdown['data']['you_send'];
-```
-
-### Rates
-
-#### List All Rates
-
-```php
-$rates = Blaaiz::rates()->list();
-echo 'Rates: ' . json_encode($rates['data']);
-```
-
-#### Search Rates by Currency Pair
-
-```php
-// Filter rates using partial matching (e.g., "USD" matches "USD/NGN")
-$usdRates = Blaaiz::rates()->list('USD');
-echo 'USD Rates: ' . json_encode($usdRates['data']);
-```
-
-### Swap
-
-#### Swap Money Between Business Wallets
-
-```php
-$swap = Blaaiz::swaps()->swap([
-    'from_business_wallet_id' => 'source-wallet-id',
-    'to_business_wallet_id' => 'destination-wallet-id',
-    'amount' => 100,
-    'amount_type' => 'from', // 'from' (debit amount) or 'to' (credit amount)
-]);
-
-echo 'Swap Status: ' . $swap['data']['business_swap_transaction']['status'];
-echo 'Rate: ' . $swap['data']['business_swap_transaction']['from_exchange_rate'];
-```
-
-### Webhooks
-
-#### Register Webhooks
-
-```php
-$webhook = Blaaiz::webhooks()->register([
-    'collection_url' => 'https://your-domain.com/webhooks/collection',
-    'payout_url' => 'https://your-domain.com/webhooks/payout'
-]);
-```
-
-#### Get Webhook Configuration
-
-```php
-$webhookConfig = Blaaiz::webhooks()->get();
-echo 'Webhook URLs: ' . json_encode($webhookConfig['data']);
-```
-
-#### Replay Webhook
-
-```php
-$replay = Blaaiz::webhooks()->replay([
-    'transaction_id' => 'transaction-id'
-]);
-```
-
-#### Simulate Interac Webhook (Non-Production Only)
-
-```php
-// For testing Interac webhooks in development/sandbox environment
-$simulate = Blaaiz::webhooks()->simulateInteracWebhook([
-    'interac_email' => 'sender@example.com'
-]);
-
-echo 'Message: ' . $simulate['message'];
-```
-
-## Advanced Usage
-
-### Complete Payout Workflow
-
-```php
-$completePayoutResult = Blaaiz::createCompletePayout([
-    'customer_data' => [
-        'first_name' => 'John',
-        'last_name' => 'Doe',
-        'type' => 'individual',
-        'email' => 'john@example.com',
-        'country' => 'NG',
-        'id_type' => 'passport',
-        'id_number' => 'A12345678'
-    ],
-    'payout_data' => [
-        'wallet_id' => 'wallet-id',
-        'method' => 'bank_transfer',
-        'from_amount' => 1000,
-        'from_currency_id' => '1',
-        'to_currency_id' => '1',
-        'account_number' => '0123456789',
-        'bank_id' => '1',
-        'phone_number' => '+2348012345678'
-    ]
-]);
-
-echo 'Customer ID: ' . $completePayoutResult['customer_id'];
-echo 'Payout: ' . json_encode($completePayoutResult['payout']);
-echo 'Fees: ' . json_encode($completePayoutResult['fees']);
-```
-
-### Complete Collection Workflow
-
-```php
-$completeCollectionResult = Blaaiz::createCompleteCollection([
-    'customer_data' => [
-        'first_name' => 'Jane',
-        'last_name' => 'Smith',
-        'type' => 'individual',
-        'email' => 'jane@example.com',
-        'country' => 'NG',
-        'id_type' => 'drivers_license',
-        'id_number' => 'ABC123456'
-    ],
-    'collection_data' => [
-        'method' => 'card',
-        'amount' => 5000,
-        'wallet_id' => 'wallet-id'
-    ],
-    'create_vba' => true // Optionally create a virtual bank account
-]);
-
-echo 'Customer ID: ' . $completeCollectionResult['customer_id'];
-echo 'Collection: ' . json_encode($completeCollectionResult['collection']);
-echo 'Virtual Account: ' . json_encode($completeCollectionResult['virtual_account']);
-```
-
-### Using Dependency Injection
-
-```php
-<?php
-
-namespace App\Http\Controllers;
-
-use Blaaiz\LaravelSdk\Blaaiz;
-use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
-use Illuminate\Http\Request;
-
-class PaymentController extends Controller
-{
-    public function __construct(private Blaaiz $blaaiz)
-    {
-    }
-
-    public function createPayout(Request $request)
-    {
-        try {
-            $payout = $this->blaaiz->payouts()->initiate([
-                'wallet_id' => $request->input('wallet_id'),
-                'method' => 'bank_transfer',
-                'from_amount' => $request->input('amount'),
-                'from_currency_id' => $request->input('from_currency_id'),
-                'to_currency_id' => $request->input('to_currency_id'),
-                'account_number' => $request->input('account_number'),
-                'bank_id' => $request->input('bank_id')
-            ]);
-
-            return response()->json($payout);
-        } catch (BlaaizException $e) {
-            return response()->json([
-                'error' => $e->getMessage(),
-                'status' => $e->getStatus(),
-                'error_code' => $e->getErrorCode()
-            ], $e->getStatus() ?: 500);
-        }
-    }
-}
-```
-
-## Error Handling
-
-The SDK uses a custom `BlaaizException` class that provides detailed error information:
-
-```php
-use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
-
-try {
-    $customer = Blaaiz::customers()->create($invalidData);
-} catch (BlaaizException $e) {
-    echo 'Blaaiz API Error: ' . $e->getMessage();
-    echo 'Status Code: ' . $e->getStatus();
-    echo 'Error Code: ' . $e->getErrorCode();
-    
-    // Check error type
-    if ($e->isClientError()) {
-        // 4xx errors - client/validation issues
-        echo 'Client error detected';
-    } elseif ($e->isServerError()) {
-        // 5xx errors - server issues
-        echo 'Server error detected';
-    }
-    
-    // Get array representation
-    $errorArray = $e->toArray();
-    Log::error('Blaaiz API Error', $errorArray);
-}
-```
-
-## Rate Limiting
-
-The Blaaiz API has a rate limit of 100 requests per minute. The SDK automatically includes rate limit headers in responses:
-
-- `X-RateLimit-Limit`: Maximum requests per minute
-- `X-RateLimit-Remaining`: Remaining requests in current window
-- `X-RateLimit-Reset`: When the rate limit resets
-
-## Webhook Handling
-
-### Webhook Signature Verification
-
-The SDK provides built-in webhook signature verification to ensure webhook authenticity:
-
-```php
-use Blaaiz\LaravelSdk\Facades\Blaaiz;
-
-// Method 1: Verify signature manually
-$isValid = Blaaiz::webhooks()->verifySignature(
-    $payload,        // Raw webhook payload (string or array)
-    $signature,      // Signature from webhook headers
-    $webhookSecret   // Your webhook secret key
-);
-
-if ($isValid) {
-    echo 'Webhook signature is valid';
-} else {
-    echo 'Invalid webhook signature';
-}
-
-// Method 2: Construct verified event (recommended)
-try {
-    $event = Blaaiz::webhooks()->constructEvent(
-        $payload,        // Raw webhook payload
-        $signature,      // Signature from webhook headers  
-        $webhookSecret   // Your webhook secret key
-    );
-    
-    echo 'Verified event: ' . json_encode($event);
-    // $event['verified'] will be true
-    // $event['timestamp'] will contain verification timestamp
-} catch (BlaaizException $e) {
-    echo 'Webhook verification failed: ' . $e->getMessage();
-}
-```
-
-### Complete Laravel Webhook Handler
-
-```php
-<?php
-
-namespace App\Http\Controllers;
-
-use Blaaiz\LaravelSdk\Facades\Blaaiz;
-use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Log;
-
-class WebhookController extends Controller
-{
-    private string $webhookSecret;
-
-    public function __construct()
-    {
-        // Get webhook secret from config or environment
-        $this->webhookSecret = config('blaaiz.webhook_secret') ?: env('BLAAIZ_WEBHOOK_SECRET');
-    }
-
-    public function collection(Request $request): Response
-    {
-        $signature = $request->header('x-blaaiz-signature');
-        $payload = $request->getContent();
-
-        try {
-            // Verify webhook signature and construct event
-            $event = Blaaiz::webhooks()->constructEvent($payload, $signature, $this->webhookSecret);
-
-            Log::info('Verified collection event', [
-                'transaction_id' => $event['transaction_id'],
-                'status' => $event['status'],
-                'amount' => $event['amount'],
-                'currency' => $event['currency'],
-                'verified' => $event['verified']
-            ]);
-
-            // Process the collection
-            // Update your database, send notifications, etc.
-
-            return response()->json(['received' => true]);
-        } catch (BlaaizException $e) {
-            Log::error('Webhook verification failed', ['error' => $e->getMessage()]);
-            return response()->json(['error' => 'Invalid signature'], 400);
-        }
-    }
-
-    public function payout(Request $request): Response
-    {
-        $signature = $request->header('x-blaaiz-signature');
-        $payload = $request->getContent();
-
-        try {
-            // Verify webhook signature and construct event
-            $event = Blaaiz::webhooks()->constructEvent($payload, $signature, $this->webhookSecret);
-
-            Log::info('Verified payout event', [
-                'transaction_id' => $event['transaction_id'],
-                'status' => $event['status'],
-                'recipient' => $event['recipient'],
-                'verified' => $event['verified']
-            ]);
-
-            // Process the payout completion
-            // Update your database, send notifications, etc.
-
-            return response()->json(['received' => true]);
-        } catch (BlaaizException $e) {
-            Log::error('Webhook verification failed', ['error' => $e->getMessage()]);
-            return response()->json(['error' => 'Invalid signature'], 400);
-        }
-    }
-}
-```
-
-### Webhook Routes
-
-Add these routes to your `routes/web.php` or `routes/api.php`:
-
-```php
-use App\Http\Controllers\WebhookController;
-
-// Webhook routes (disable CSRF protection for these routes)
-Route::post('/webhooks/collection', [WebhookController::class, 'collection'])->name('webhooks.collection');
-Route::post('/webhooks/payout', [WebhookController::class, 'payout'])->name('webhooks.payout');
-```
-
-### Disable CSRF Protection for Webhooks
-
-Add webhook routes to the CSRF exception list in `app/Http/Middleware/VerifyCsrfToken.php`:
-
-```php
-protected $except = [
-    'webhooks/*',
-];
-```
-
-## Environment Configuration
-
-The SDK configuration can be customized via the `.env` file:
+You can also authenticate with a legacy API key:
 
 ```env
-# OAuth 2.0 Authentication (Recommended)
-BLAAIZ_CLIENT_ID=your-client-id
-BLAAIZ_CLIENT_SECRET=your-client-secret
-
-# Legacy API Key Authentication (fallback)
-BLAAIZ_API_KEY=your-api-key-here
-
-# Optional - OAuth scope (defaults to all scopes; override to request a subset)
-# BLAAIZ_OAUTH_SCOPE=wallet:read payout:create transaction:read
-
-# Optional - Environment URLs
-BLAAIZ_API_URL=https://api-dev.blaaiz.com  # Development (default)
-# BLAAIZ_API_URL=https://api-prod.blaaiz.com  # Production
-
-# Optional - Request timeout
-BLAAIZ_TIMEOUT=30
-
-# Optional - Webhook secret for signature verification
-BLAAIZ_WEBHOOK_SECRET=your-webhook-secret-here
+BLAAIZ_API_KEY=your-api-key
+BLAAIZ_API_URL=https://api-dev.blaaiz.com
 ```
 
-### Configuration File
+```php
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
 
-After publishing the config file with `php artisan vendor:publish --tag=blaaiz-config`, you can modify `config/blaaiz.php`:
+$isConnected = Blaaiz::testConnection();
+$wallets = Blaaiz::wallets()->list();
+```
+
+When both OAuth credentials and an API key are configured, OAuth is used.
+
+### Publish configuration
+
+```bash
+php artisan vendor:publish --tag=blaaiz-config
+```
+
+### Basic usage with dependency injection
 
 ```php
-<?php
+use Blaaiz\LaravelSdk\Blaaiz;
 
+class RatesController
+{
+    public function __invoke(Blaaiz $blaaiz)
+    {
+        return response()->json($blaaiz->rates()->list());
+    }
+}
+```
+
+## Configuration
+
+The published config file exposes these options:
+
+```php
 return [
     'api_key' => env('BLAAIZ_API_KEY', ''),
     'client_id' => env('BLAAIZ_CLIENT_ID', ''),
@@ -949,34 +79,126 @@ return [
     'oauth_scope' => env('BLAAIZ_OAUTH_SCOPE', ''),
     'base_url' => env('BLAAIZ_API_URL', 'https://api-dev.blaaiz.com'),
     'timeout' => env('BLAAIZ_TIMEOUT', 30),
+    'webhook_secret' => env('BLAAIZ_WEBHOOK_SECRET', ''),
 ];
 ```
 
-## Best Practices
+## Available Services
 
-1. **Always validate customer data before creating customers**
-2. **Use the fees API to calculate and display fees to users**
-3. **Always verify webhook signatures using the SDK's built-in methods**
-4. **Store customer IDs and transaction IDs for tracking**
-5. **Handle rate limiting gracefully with exponential backoff**
-6. **Use environment variables for API keys and webhook secrets**
-7. **Implement proper error handling and logging**
-8. **Test webhook endpoints thoroughly with signature verification**
-9. **Disable CSRF protection for webhook endpoints**
-10. **Return appropriate HTTP status codes from webhook handlers (200 for success, 400 for invalid signatures)**
+- `customers()`
+- `collections()`
+- `payouts()`
+- `wallets()`
+- `virtualBankAccounts()`
+- `transactions()`
+- `banks()`
+- `currencies()`
+- `fees()`
+- `files()`
+- `webhooks()`
+- `rates()`
+- `swaps()`
 
-## Requirements
+These services are also exposed as public properties on the underlying SDK instance.
 
-- PHP 8.1 or higher
-- Laravel 11.0 or 12.0
-- GuzzleHTTP 7.0 or higher
+## Common Examples
 
-## Support
+### Create a customer
 
-For support and additional documentation:
-- Email: onboarding@blaaiz.com
-- Documentation: https://docs.business.blaaiz.com
+```php
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
 
-## License
+$customer = Blaaiz::customers()->create([
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'type' => 'individual',
+    'email' => 'john.doe@example.com',
+    'country' => 'NG',
+    'id_type' => 'passport',
+    'id_number' => 'A12345678',
+]);
+```
 
-This SDK is provided under the MIT License
+### Initiate a payout
+
+```php
+$payout = Blaaiz::payouts()->initiate([
+    'wallet_id' => 'wallet-id',
+    'customer_id' => 'customer-id',
+    'method' => 'bank_transfer',
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'NGN',
+    'from_amount' => 100,
+    'bank_id' => 'bank-id',
+    'account_number' => '0123456789',
+]);
+```
+
+### Upload a KYC document
+
+```php
+$result = Blaaiz::customers()->uploadFileComplete('customer-id', [
+    'file' => storage_path('app/private/passport.pdf'),
+    'file_category' => 'identity',
+]);
+```
+
+### Verify a webhook
+
+```php
+$event = Blaaiz::webhooks()->constructEvent(
+    $request->getContent(),
+    $request->header('X-Blaaiz-Signature', ''),
+    $request->header('X-Blaaiz-Timestamp', ''),
+    config('blaaiz.webhook_secret')
+);
+```
+
+## API Reference
+
+- [Root SDK helpers](docs/root-sdk.md)
+- [Customers](docs/customers.md)
+- [Collections](docs/collections.md)
+- [Payouts](docs/payouts.md)
+- [Wallets and virtual bank accounts](docs/wallets-and-vbas.md)
+- [Transactions, banks, currencies, and rates](docs/transactions-banks-currencies-rates.md)
+- [Fees and files](docs/fees-files.md)
+- [Webhooks](docs/webhooks.md)
+- [Swaps](docs/swaps.md)
+
+## Runnable Examples
+
+See [examples/README.md](examples/README.md) for Laravel-oriented example classes and snippets.
+
+## High-Level Helpers
+
+The root SDK object includes:
+
+- `testConnection()`
+- `createCompletePayout(array $config)`
+- `createCompleteCollection(array $config)`
+
+These helpers compose the lower-level services for common workflows.
+
+## Error Handling
+
+```php
+use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+
+try {
+    $rates = Blaaiz::rates()->list();
+} catch (BlaaizException $e) {
+    report($e);
+
+    return response()->json($e->toArray(), $e->getStatus() ?? 500);
+}
+```
+
+## Development
+
+```bash
+composer test
+composer analyse
+composer format
+```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,26 @@ composer require blaaiz/blaaiz-laravel-sdk
 
 ## Quick Start
 
-```php
-// Add to your .env file
-BLAAIZ_API_KEY=your-api-key-here
-BLAAIZ_BASE_URL=https://api-dev.blaaiz.com  // For development
-// BLAAIZ_BASE_URL=https://api.blaaiz.com  // For production
+### Authentication
 
+The SDK supports two authentication methods. **OAuth 2.0 is recommended** for new integrations.
+
+**Option 1: OAuth 2.0 (Recommended)**
+```env
+BLAAIZ_CLIENT_ID=your-client-id
+BLAAIZ_CLIENT_SECRET=your-client-secret
+BLAAIZ_API_URL=https://api-dev.blaaiz.com
+```
+
+**Option 2: Legacy API Key**
+```env
+BLAAIZ_API_KEY=your-api-key-here
+BLAAIZ_API_URL=https://api-dev.blaaiz.com
+```
+
+When both OAuth credentials and an API key are configured, OAuth takes priority.
+
+```php
 // Publish configuration (optional)
 php artisan vendor:publish --tag=blaaiz-config
 
@@ -38,6 +52,9 @@ echo $isConnected ? 'API Connected' : 'Connection Failed';
 - **Files**: Document upload with pre-signed URLs
 - **Fees**: Real-time fee calculations and breakdowns
 - **Banks & Currencies**: Access to supported banks and currencies
+- **Rates**: View exchange rates with optional currency pair filtering
+- **Swap**: Swap money between business wallets
+- **OAuth 2.0 Authentication**: Client credentials flow with automatic token management
 - **Laravel Integration**: Native service provider, facade, and configuration
 
 ## Supported Currencies & Methods
@@ -547,6 +564,39 @@ $feeBreakdown = Blaaiz::fees()->getBreakdown([
 echo 'You send: ' . $feeBreakdown['data']['you_send'];
 ```
 
+### Rates
+
+#### List All Rates
+
+```php
+$rates = Blaaiz::rates()->list();
+echo 'Rates: ' . json_encode($rates['data']);
+```
+
+#### Search Rates by Currency Pair
+
+```php
+// Filter rates using partial matching (e.g., "USD" matches "USD/NGN")
+$usdRates = Blaaiz::rates()->list('USD');
+echo 'USD Rates: ' . json_encode($usdRates['data']);
+```
+
+### Swap
+
+#### Swap Money Between Business Wallets
+
+```php
+$swap = Blaaiz::swaps()->swap([
+    'from_business_wallet_id' => 'source-wallet-id',
+    'to_business_wallet_id' => 'destination-wallet-id',
+    'amount' => 100,
+    'amount_type' => 'from', // 'from' (debit amount) or 'to' (credit amount)
+]);
+
+echo 'Swap Status: ' . $swap['data']['business_swap_transaction']['status'];
+echo 'Rate: ' . $swap['data']['business_swap_transaction']['from_exchange_rate'];
+```
+
 ### Webhooks
 
 #### Register Webhooks
@@ -864,12 +914,19 @@ protected $except = [
 The SDK configuration can be customized via the `.env` file:
 
 ```env
-# Required
+# OAuth 2.0 Authentication (Recommended)
+BLAAIZ_CLIENT_ID=your-client-id
+BLAAIZ_CLIENT_SECRET=your-client-secret
+
+# Legacy API Key Authentication (fallback)
 BLAAIZ_API_KEY=your-api-key-here
 
+# Optional - OAuth scope (defaults to all scopes; override to request a subset)
+# BLAAIZ_OAUTH_SCOPE=wallet:read payout:create transaction:read
+
 # Optional - Environment URLs
-BLAAIZ_BASE_URL=https://api-dev.blaaiz.com  # Development (default)
-# BLAAIZ_BASE_URL=https://api.blaaiz.com    # Production
+BLAAIZ_API_URL=https://api-dev.blaaiz.com  # Development (default)
+# BLAAIZ_API_URL=https://api-prod.blaaiz.com  # Production
 
 # Optional - Request timeout
 BLAAIZ_TIMEOUT=30
@@ -886,10 +943,12 @@ After publishing the config file with `php artisan vendor:publish --tag=blaaiz-c
 <?php
 
 return [
-    'api_key' => env('BLAAIZ_API_KEY'),
-    'base_url' => env('BLAAIZ_BASE_URL', 'https://api-dev.blaaiz.com'),
+    'api_key' => env('BLAAIZ_API_KEY', ''),
+    'client_id' => env('BLAAIZ_CLIENT_ID', ''),
+    'client_secret' => env('BLAAIZ_CLIENT_SECRET', ''),
+    'oauth_scope' => env('BLAAIZ_OAUTH_SCOPE', ''),
+    'base_url' => env('BLAAIZ_API_URL', 'https://api-dev.blaaiz.com'),
     'timeout' => env('BLAAIZ_TIMEOUT', 30),
-    'webhook_secret' => env('BLAAIZ_WEBHOOK_SECRET'),
 ];
 ```
 
@@ -909,7 +968,7 @@ return [
 ## Requirements
 
 - PHP 8.1 or higher
-- Laravel 9.0, 10.0, or 11.0
+- Laravel 11.0 or 12.0
 - GuzzleHTTP 7.0 or higher
 
 ## Support

--- a/config/blaaiz.php
+++ b/config/blaaiz.php
@@ -10,7 +10,21 @@ return [
     | This key is used to authenticate with the Blaaiz API.
     |
     */
-    'api_key' => env('BLAAIZ_API_KEY', 'test-key'),
+    'api_key' => env('BLAAIZ_API_KEY', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Blaaiz OAuth Credentials
+    |--------------------------------------------------------------------------
+    |
+    | OAuth 2.0 client credentials for the Blaaiz API. When both client_id
+    | and client_secret are provided, the SDK will use OAuth authentication.
+    | Otherwise, it falls back to the legacy API key above.
+    |
+    */
+    'client_id' => env('BLAAIZ_CLIENT_ID', ''),
+    'client_secret' => env('BLAAIZ_CLIENT_SECRET', ''),
+    'oauth_scope' => env('BLAAIZ_OAUTH_SCOPE', ''),
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,61 @@
+# Collections
+
+## `initiate(array $collectionData)`
+
+```php
+$collection = $blaaiz->collections()->initiate([
+    'customer_id' => 'customer-id',
+    'wallet_id' => 'wallet-id',
+    'amount' => 100,
+    'currency' => 'EUR',
+    'method' => 'open_banking',
+    'redirect_url' => 'https://example.com/callback',
+]);
+```
+
+Required fields:
+
+- `customer_id`
+- `wallet_id`
+- `amount`
+- `currency`
+- `method`
+
+## `initiateCrypto(array $cryptoData)`
+
+```php
+$cryptoCollection = $blaaiz->collections()->initiateCrypto([
+    'wallet_id' => 'wallet-id',
+    'currency' => 'USDT',
+    'network' => 'TRON',
+]);
+```
+
+## `attachCustomer(array $attachData)`
+
+Associates a customer with an existing collection transaction.
+
+```php
+$attached = $blaaiz->collections()->attachCustomer([
+    'customer_id' => 'customer-id',
+    'transaction_id' => 'transaction-id',
+]);
+```
+
+## `getCryptoNetworks()`
+
+```php
+$networks = $blaaiz->collections()->getCryptoNetworks();
+```
+
+## `acceptInteracMoneyRequest(array $interacData)`
+
+```php
+$result = $blaaiz->collections()->acceptInteracMoneyRequest([
+    'reference_number' => 'interac-reference',
+    'security_answer' => 'answer',
+    'email' => 'sender@example.com',
+]);
+```
+
+Only `reference_number` is enforced by the SDK. Other fields depend on the flow you are using.

--- a/docs/customers.md
+++ b/docs/customers.md
@@ -1,0 +1,152 @@
+# Customers
+
+## `create(array $customerData)`
+
+```php
+$customer = $blaaiz->customers()->create([
+    'first_name' => 'John',
+    'last_name' => 'Doe',
+    'type' => 'individual',
+    'email' => 'john@example.com',
+    'country' => 'NG',
+    'id_type' => 'passport',
+    'id_number' => 'A12345678',
+]);
+```
+
+For business customers, provide `business_name` instead of `first_name` and `last_name`.
+
+## `list()`
+
+```php
+$customers = $blaaiz->customers()->list();
+```
+
+## `get(string $customerId)`
+
+```php
+$customer = $blaaiz->customers()->get('customer-id');
+```
+
+## `update(string $customerId, array $updateData)`
+
+```php
+$updatedCustomer = $blaaiz->customers()->update('customer-id', [
+    'email' => 'updated@example.com',
+]);
+```
+
+## `addKyc(string $customerId, array $kycData)`
+
+```php
+$kyc = $blaaiz->customers()->addKyc('customer-id', [
+    'document_type' => 'passport',
+    'document_number' => 'A12345678',
+]);
+```
+
+## `uploadFiles(string $customerId, array $fileData)`
+
+Associates previously uploaded file IDs with a customer.
+
+```php
+$association = $blaaiz->customers()->uploadFiles('customer-id', [
+    'id_file' => 'file-id',
+]);
+```
+
+Common file keys:
+
+- `id_file`
+- `proof_of_address_file`
+- `liveness_check_file`
+
+## `uploadFileComplete(string $customerId, array $fileOptions)`
+
+Handles the full 3-step file flow:
+
+1. Gets a presigned URL
+2. Uploads the file
+3. Associates the file with the customer
+
+Required fields:
+
+- `file`
+- `file_category`
+
+Allowed `file_category` values:
+
+- `identity`
+- `proof_of_address`
+- `liveness_check`
+
+Optional fields:
+
+- `filename`
+- `content_type`
+
+### Local file path
+
+```php
+$result = $blaaiz->customers()->uploadFileComplete('customer-id', [
+    'file' => __DIR__ . '/passport.pdf',
+    'file_category' => 'identity',
+]);
+```
+
+### Raw file contents
+
+```php
+$result = $blaaiz->customers()->uploadFileComplete('customer-id', [
+    'file' => file_get_contents(__DIR__ . '/bill.pdf'),
+    'file_category' => 'proof_of_address',
+    'filename' => 'bill.pdf',
+    'content_type' => 'application/pdf',
+]);
+```
+
+### Base64 string
+
+```php
+$result = $blaaiz->customers()->uploadFileComplete('customer-id', [
+    'file' => $base64Image,
+    'file_category' => 'identity',
+    'filename' => 'passport.png',
+    'content_type' => 'image/png',
+]);
+```
+
+### Data URL
+
+```php
+$result = $blaaiz->customers()->uploadFileComplete('customer-id', [
+    'file' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...',
+    'file_category' => 'liveness_check',
+]);
+```
+
+### Public URL
+
+```php
+$result = $blaaiz->customers()->uploadFileComplete('customer-id', [
+    'file' => 'https://example.com/documents/passport.jpg',
+    'file_category' => 'identity',
+]);
+```
+
+The response includes the API response plus:
+
+- `file_id`
+- `presigned_url`
+
+## `listBeneficiaries(string $customerId)`
+
+```php
+$beneficiaries = $blaaiz->customers()->listBeneficiaries('customer-id');
+```
+
+## `getBeneficiary(string $customerId, string $beneficiaryId)`
+
+```php
+$beneficiary = $blaaiz->customers()->getBeneficiary('customer-id', 'beneficiary-id');
+```

--- a/docs/fees-files.md
+++ b/docs/fees-files.md
@@ -1,0 +1,50 @@
+# Fees And Files
+
+## Fees
+
+### `getBreakdown(array $feeData)`
+
+Provide:
+
+- `from_currency_id`
+- `to_currency_id`
+- one of `from_amount` or `to_amount`
+
+```php
+$fees = $blaaiz->fees()->getBreakdown([
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'NGN',
+    'from_amount' => 100,
+]);
+```
+
+You can also quote by target amount:
+
+```php
+$fees = $blaaiz->fees()->getBreakdown([
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'NGN',
+    'to_amount' => 150000,
+]);
+```
+
+## Files
+
+### `getPresignedUrl(array $fileData)`
+
+Gets a presigned URL for manual file uploads.
+
+```php
+$upload = $blaaiz->files()->getPresignedUrl([
+    'customer_id' => 'customer-id',
+    'file_category' => 'identity',
+]);
+```
+
+Typical manual flow:
+
+1. Call `getPresignedUrl()`
+2. Upload the file contents to the returned URL
+3. Associate the returned `file_id` with `customers()->uploadFiles()`
+
+If you want the SDK to do all 3 steps for you, use `customers()->uploadFileComplete()` instead.

--- a/docs/payouts.md
+++ b/docs/payouts.md
@@ -1,0 +1,142 @@
+# Payouts
+
+## `initiate(array $payoutData)`
+
+```php
+$payout = $blaaiz->payouts()->initiate([
+    'wallet_id' => 'wallet-id',
+    'customer_id' => 'customer-id',
+    'method' => 'bank_transfer',
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'NGN',
+    'from_amount' => 100,
+    'bank_id' => 'bank-id',
+    'account_number' => '0123456789',
+]);
+```
+
+Always required:
+
+- `wallet_id`
+- `customer_id`
+- `method`
+- `from_currency_id`
+- `to_currency_id`
+- one of `from_amount` or `to_amount`
+
+### `bank_transfer`
+
+Extra requirements depend on `to_currency_id`.
+
+For `NGN`:
+
+- `bank_id`
+- `account_number`
+
+For `GBP`:
+
+- `sort_code`
+- `account_number`
+- `account_name`
+
+For `EUR`:
+
+- `iban`
+- `bic_code`
+- `account_name`
+
+### `interac`
+
+```php
+$payout = $blaaiz->payouts()->initiate([
+    'wallet_id' => 'wallet-id',
+    'customer_id' => 'customer-id',
+    'method' => 'interac',
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'CAD',
+    'from_amount' => 100,
+    'email' => 'recipient@example.com',
+    'interac_first_name' => 'John',
+    'interac_last_name' => 'Doe',
+]);
+```
+
+Required:
+
+- `email`
+- `interac_first_name`
+- `interac_last_name`
+
+### `ach`
+
+```php
+$payout = $blaaiz->payouts()->initiate([
+    'wallet_id' => 'wallet-id',
+    'customer_id' => 'customer-id',
+    'method' => 'ach',
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'USD',
+    'from_amount' => 100,
+    'type' => 'individual',
+    'account_number' => '1234567890',
+    'account_name' => 'John Doe',
+    'account_type' => 'checking',
+    'bank_name' => 'Test Bank',
+    'routing_number' => '021000021',
+]);
+```
+
+Required:
+
+- `type`
+- `account_number`
+- `account_name`
+- `account_type`
+- `bank_name`
+- `routing_number`
+
+### `wire`
+
+```php
+$payout = $blaaiz->payouts()->initiate([
+    'wallet_id' => 'wallet-id',
+    'customer_id' => 'customer-id',
+    'method' => 'wire',
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'USD',
+    'from_amount' => 100,
+    'type' => 'business',
+    'account_number' => '1234567890',
+    'account_name' => 'Example Ltd',
+    'account_type' => 'checking',
+    'bank_name' => 'Test Bank',
+    'routing_number' => '021000021',
+    'swift_code' => 'BOFAUS3N',
+]);
+```
+
+Adds one more required field:
+
+- `swift_code`
+
+### `crypto`
+
+```php
+$payout = $blaaiz->payouts()->initiate([
+    'wallet_id' => 'wallet-id',
+    'customer_id' => 'customer-id',
+    'method' => 'crypto',
+    'from_currency_id' => 'USD',
+    'to_currency_id' => 'USDT',
+    'from_amount' => 100,
+    'wallet_address' => 'TExampleAddress',
+    'wallet_token' => 'USDT',
+    'wallet_network' => 'TRON',
+]);
+```
+
+Required:
+
+- `wallet_address`
+- `wallet_token`
+- `wallet_network`

--- a/docs/root-sdk.md
+++ b/docs/root-sdk.md
@@ -1,0 +1,139 @@
+# Root SDK
+
+## `__construct(array $options = [])`
+
+The package registers the SDK in Laravel's service container and facade automatically.
+In most Laravel apps you will use either the facade or dependency injection instead of constructing it manually.
+
+### Facade usage
+
+```php
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+
+$rates = Blaaiz::rates()->list();
+```
+
+### Dependency injection
+
+```php
+use Blaaiz\LaravelSdk\Blaaiz;
+
+class RatesController
+{
+    public function __invoke(Blaaiz $blaaiz)
+    {
+        return response()->json($blaaiz->rates()->list());
+    }
+}
+```
+
+### Manual construction
+
+```php
+use Blaaiz\LaravelSdk\Blaaiz;
+
+$blaaiz = new Blaaiz([
+    'client_id' => 'your-client-id',
+    'client_secret' => 'your-client-secret',
+    'base_url' => 'https://api-dev.blaaiz.com',
+    'timeout' => 30,
+]);
+```
+
+You can also manually construct the SDK with a legacy API key:
+
+```php
+use Blaaiz\LaravelSdk\Blaaiz;
+
+$blaaiz = new Blaaiz([
+    'api_key' => 'your-api-key',
+    'base_url' => 'https://api-dev.blaaiz.com',
+    'timeout' => 30,
+]);
+```
+
+## Service accessors
+
+The root SDK exposes service accessors:
+
+- `customers()`
+- `collections()`
+- `payouts()`
+- `wallets()`
+- `virtualBankAccounts()`
+- `transactions()`
+- `banks()`
+- `currencies()`
+- `fees()`
+- `files()`
+- `webhooks()`
+- `rates()`
+- `swaps()`
+
+These are also available as public properties on the underlying SDK instance.
+
+## `testConnection()`
+
+Performs a lightweight connectivity check by calling the currencies endpoint.
+
+```php
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+
+if (Blaaiz::testConnection()) {
+    logger()->info('Blaaiz connected');
+}
+```
+
+## `createCompletePayout(array $payoutConfig)`
+
+Creates a customer when needed, calculates fees, and initiates the payout.
+
+```php
+$result = Blaaiz::createCompletePayout([
+    'customer_data' => [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'type' => 'individual',
+        'email' => 'john@example.com',
+        'country' => 'NG',
+        'id_type' => 'passport',
+        'id_number' => 'A12345678',
+    ],
+    'payout_data' => [
+        'wallet_id' => 'wallet-id',
+        'method' => 'bank_transfer',
+        'from_currency_id' => 'USD',
+        'to_currency_id' => 'NGN',
+        'from_amount' => 100,
+        'bank_id' => 'bank-id',
+        'account_number' => '0123456789',
+    ],
+]);
+```
+
+You can omit `customer_data` when `payout_data.customer_id` is already available.
+
+## `createCompleteCollection(array $collectionConfig)`
+
+Creates a customer when needed, optionally creates a virtual bank account, and initiates the collection.
+
+```php
+$result = Blaaiz::createCompleteCollection([
+    'customer_data' => [
+        'first_name' => 'Jane',
+        'last_name' => 'Doe',
+        'type' => 'individual',
+        'email' => 'jane@example.com',
+        'country' => 'NG',
+        'id_type' => 'passport',
+        'id_number' => 'B12345678',
+    ],
+    'collection_data' => [
+        'wallet_id' => 'wallet-id',
+        'amount' => 100,
+        'currency' => 'NGN',
+        'method' => 'bank_transfer',
+    ],
+    'create_vba' => true,
+]);
+```

--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -1,0 +1,17 @@
+# Swaps
+
+## `swap(array $data)`
+
+```php
+$swap = $blaaiz->swaps()->swap([
+    'from_business_wallet_id' => 'wallet-id-usd',
+    'to_business_wallet_id' => 'wallet-id-ngn',
+    'amount' => 100,
+]);
+```
+
+Required:
+
+- `from_business_wallet_id`
+- `to_business_wallet_id`
+- `amount`

--- a/docs/transactions-banks-currencies-rates.md
+++ b/docs/transactions-banks-currencies-rates.md
@@ -1,0 +1,58 @@
+# Transactions, Banks, Currencies, And Rates
+
+## Transactions
+
+### `list(array $filters = [])`
+
+```php
+$transactions = $blaaiz->transactions()->list([
+    'status' => 'completed',
+    'page' => 1,
+]);
+```
+
+### `get(string $transactionId)`
+
+```php
+$transaction = $blaaiz->transactions()->get('transaction-id');
+```
+
+## Banks
+
+### `list()`
+
+```php
+$banks = $blaaiz->banks()->list();
+```
+
+### `lookupAccount(array $lookupData)`
+
+```php
+$account = $blaaiz->banks()->lookupAccount([
+    'account_number' => '0123456789',
+    'bank_id' => 'bank-id',
+]);
+```
+
+Required:
+
+- `account_number`
+- `bank_id`
+
+## Currencies
+
+### `list()`
+
+```php
+$currencies = $blaaiz->currencies()->list();
+```
+
+## Rates
+
+### `list(?string $searchTerm = null)`
+
+```php
+$allRates = $blaaiz->rates()->list();
+
+$usdRates = $blaaiz->rates()->list('USD');
+```

--- a/docs/wallets-and-vbas.md
+++ b/docs/wallets-and-vbas.md
@@ -1,0 +1,73 @@
+# Wallets And Virtual Bank Accounts
+
+## Wallets
+
+### `list()`
+
+```php
+$wallets = $blaaiz->wallets()->list();
+```
+
+### `get(string $walletId)`
+
+```php
+$wallet = $blaaiz->wallets()->get('wallet-id');
+```
+
+## Virtual bank accounts
+
+### `create(array $vbaData)`
+
+```php
+$vba = $blaaiz->virtualBankAccounts()->create([
+    'wallet_id' => 'wallet-id',
+    'account_name' => 'John Doe',
+]);
+```
+
+Required:
+
+- `wallet_id`
+
+### `list(?string $walletId = null, ?string $customerId = null)`
+
+```php
+$allVbas = $blaaiz->virtualBankAccounts()->list();
+
+$walletVbas = $blaaiz->virtualBankAccounts()->list('wallet-id');
+
+$customerVbas = $blaaiz->virtualBankAccounts()->list(null, 'customer-id');
+```
+
+### `get(string $vbaId)`
+
+```php
+$vba = $blaaiz->virtualBankAccounts()->get('vba-id');
+```
+
+### `close(string $vbaId, ?string $reason = null)`
+
+```php
+$closed = $blaaiz->virtualBankAccounts()->close('vba-id', 'No longer needed');
+```
+
+### `getIdentificationType(?string $customerId = null, ?string $country = null, ?string $type = null)`
+
+Provide either:
+
+- `customerId`
+
+or both:
+
+- `country`
+- `type`
+
+```php
+$byCustomer = $blaaiz->virtualBankAccounts()->getIdentificationType('customer-id');
+
+$byCountryAndType = $blaaiz->virtualBankAccounts()->getIdentificationType(
+    null,
+    'NG',
+    'individual'
+);
+```

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,86 @@
+# Webhooks
+
+## `register(array $webhookData)`
+
+```php
+$webhook = $blaaiz->webhooks()->register([
+    'collection_url' => 'https://example.com/webhooks/collections',
+    'payout_url' => 'https://example.com/webhooks/payouts',
+]);
+```
+
+Required:
+
+- `collection_url`
+- `payout_url`
+
+## `get()`
+
+```php
+$webhook = $blaaiz->webhooks()->get();
+```
+
+## `update(array $webhookData)`
+
+```php
+$updated = $blaaiz->webhooks()->update([
+    'collection_url' => 'https://example.com/webhooks/new-collections',
+]);
+```
+
+## `replay(array $replayData)`
+
+```php
+$replay = $blaaiz->webhooks()->replay([
+    'transaction_id' => 'transaction-id',
+]);
+```
+
+Required:
+
+- `transaction_id`
+
+## `simulateInteracWebhook(array $simulateData)`
+
+```php
+$simulation = $blaaiz->webhooks()->simulateInteracWebhook([
+    'interac_email' => 'customer@example.com',
+]);
+```
+
+## `verifySignature(string $rawBody, string $signature, string $timestamp, string $secret)`
+
+```php
+$isValid = $blaaiz->webhooks()->verifySignature(
+    $payload,
+    $signature,
+    $timestamp,
+    $webhookSecret
+);
+```
+
+The signature is computed from:
+
+```text
+{timestamp}.{rawBody}
+```
+
+using `HMAC-SHA256`.
+
+## `constructEvent(string $payload, string $signature, string $timestamp, string $secret)`
+
+Verifies the signature and parses the JSON payload.
+
+```php
+$event = $blaaiz->webhooks()->constructEvent(
+    $payload,
+    $signature,
+    $timestamp,
+    $webhookSecret
+);
+```
+
+The returned array contains the webhook payload plus:
+
+- `verified => true`
+- `timestamp`

--- a/examples/Console/CheckRatesCommand.php
+++ b/examples/Console/CheckRatesCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Blaaiz\LaravelSdk\Blaaiz;
+use Illuminate\Console\Command;
+
+class CheckRatesCommand extends Command
+{
+    protected $signature = 'blaaiz:rates {searchTerm?}';
+
+    protected $description = 'Fetch Blaaiz exchange rates';
+
+    public function handle(Blaaiz $blaaiz): int
+    {
+        $rates = $blaaiz->rates()->list($this->argument('searchTerm'));
+
+        $this->line(json_encode($rates, JSON_PRETTY_PRINT));
+
+        return self::SUCCESS;
+    }
+}

--- a/examples/Http/Controllers/CustomerController.php
+++ b/examples/Http/Controllers/CustomerController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CustomerController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        $customer = Blaaiz::customers()->create($request->validate([
+            'first_name' => ['required_without:business_name', 'string'],
+            'last_name' => ['required_without:business_name', 'string'],
+            'business_name' => ['nullable', 'string'],
+            'type' => ['required', 'string'],
+            'email' => ['required', 'email'],
+            'country' => ['required', 'string', 'size:2'],
+            'id_type' => ['required', 'string'],
+            'id_number' => ['required', 'string'],
+        ]));
+
+        return response()->json($customer);
+    }
+}

--- a/examples/Http/Controllers/PayoutController.php
+++ b/examples/Http/Controllers/PayoutController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Blaaiz\LaravelSdk\Blaaiz;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PayoutController extends Controller
+{
+    public function store(Request $request, Blaaiz $blaaiz): JsonResponse
+    {
+        $payout = $blaaiz->payouts()->initiate($request->validate([
+            'wallet_id' => ['required', 'string'],
+            'customer_id' => ['required', 'string'],
+            'method' => ['required', 'string'],
+            'from_currency_id' => ['required', 'string'],
+            'to_currency_id' => ['required', 'string'],
+            'from_amount' => ['nullable', 'numeric'],
+            'to_amount' => ['nullable', 'numeric'],
+            'bank_id' => ['nullable', 'string'],
+            'account_number' => ['nullable', 'string'],
+        ]));
+
+        return response()->json($payout);
+    }
+}

--- a/examples/Http/Controllers/UploadKycController.php
+++ b/examples/Http/Controllers/UploadKycController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class UploadKycController extends Controller
+{
+    public function store(Request $request, string $customerId): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file'],
+            'file_category' => ['required', 'in:identity,proof_of_address,liveness_check'],
+        ]);
+
+        $result = Blaaiz::customers()->uploadFileComplete($customerId, [
+            'file' => $validated['file']->getRealPath(),
+            'file_category' => $validated['file_category'],
+            'filename' => $validated['file']->getClientOriginalName(),
+            'content_type' => $validated['file']->getMimeType(),
+        ]);
+
+        return response()->json($result);
+    }
+}

--- a/examples/Http/Controllers/UploadKycFromS3Controller.php
+++ b/examples/Http/Controllers/UploadKycFromS3Controller.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class UploadKycFromS3Controller extends Controller
+{
+    public function store(Request $request, string $customerId): JsonResponse
+    {
+        $validated = $request->validate([
+            'path' => ['required', 'string'],
+            'file_category' => ['required', 'in:identity,proof_of_address,liveness_check'],
+        ]);
+
+        $disk = Storage::disk('s3');
+        $path = $validated['path'];
+
+        if (! $disk->exists($path)) {
+            abort(404, 'S3 file not found.');
+        }
+
+        $result = Blaaiz::customers()->uploadFileComplete($customerId, [
+            'file' => $disk->get($path),
+            'file_category' => $validated['file_category'],
+            'filename' => basename($path),
+            'content_type' => $disk->mimeType($path) ?: null,
+        ]);
+
+        return response()->json($result);
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# Examples
+
+These examples are Laravel-oriented snippets you can drop into an application that has installed `blaaiz/blaaiz-laravel-sdk`.
+
+## What is included
+
+- `Console/CheckRatesCommand.php`: example Artisan command using dependency injection
+- `Http/Controllers/CustomerController.php`: create a customer from a controller
+- `Http/Controllers/PayoutController.php`: initiate a payout from a controller
+- `Http/Controllers/UploadKycController.php`: upload a document with `uploadFileComplete()`
+- `Http/Controllers/UploadKycFromS3Controller.php`: upload a document from an S3 disk object
+- `Webhooks/BlaaizWebhookController.php`: verify and parse incoming webhooks
+
+## Usage styles
+
+You can use the package in Laravel through:
+
+- the `Blaaiz` facade
+- dependency injection with `Blaaiz\LaravelSdk\Blaaiz`
+
+## Setup
+
+1. Install the package with Composer.
+2. Configure `BLAAIZ_CLIENT_ID` and `BLAAIZ_CLIENT_SECRET`, or `BLAAIZ_API_KEY`.
+3. Optionally publish config with `php artisan vendor:publish --tag=blaaiz-config`.
+4. Set `BLAAIZ_WEBHOOK_SECRET` if you are verifying webhook signatures.

--- a/examples/Webhooks/BlaaizWebhookController.php
+++ b/examples/Webhooks/BlaaizWebhookController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Blaaiz\LaravelSdk\Facades\Blaaiz;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BlaaizWebhookController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $event = Blaaiz::webhooks()->constructEvent(
+            $request->getContent(),
+            $request->header('X-Blaaiz-Signature', ''),
+            $request->header('X-Blaaiz-Timestamp', ''),
+            (string) config('blaaiz.webhook_secret')
+        );
+
+        return response()->json([
+            'received' => true,
+            'event' => $event,
+        ]);
+    }
+}

--- a/src/Blaaiz.php
+++ b/src/Blaaiz.php
@@ -10,6 +10,8 @@ use Blaaiz\LaravelSdk\Services\CustomerService;
 use Blaaiz\LaravelSdk\Services\FeesService;
 use Blaaiz\LaravelSdk\Services\FileService;
 use Blaaiz\LaravelSdk\Services\PayoutService;
+use Blaaiz\LaravelSdk\Services\RateService;
+use Blaaiz\LaravelSdk\Services\SwapService;
 use Blaaiz\LaravelSdk\Services\TransactionService;
 use Blaaiz\LaravelSdk\Services\VirtualBankAccountService;
 use Blaaiz\LaravelSdk\Services\WalletService;
@@ -30,10 +32,12 @@ class Blaaiz
     public FeesService $fees;
     public FileService $files;
     public WebhookService $webhooks;
+    public RateService $rates;
+    public SwapService $swaps;
 
-    public function __construct(string $apiKey, array $options = [])
+    public function __construct(array $options = [])
     {
-        $this->client = new BlaaizClient($apiKey, $options);
+        $this->client = new BlaaizClient($options);
 
         $this->customers = new CustomerService($this->client);
         $this->collections = new CollectionService($this->client);
@@ -46,6 +50,8 @@ class Blaaiz
         $this->fees = new FeesService($this->client);
         $this->files = new FileService($this->client);
         $this->webhooks = new WebhookService($this->client);
+        $this->rates = new RateService($this->client);
+        $this->swaps = new SwapService($this->client);
     }
 
     public function testConnection(): bool
@@ -193,5 +199,15 @@ class Blaaiz
     public function webhooks(): WebhookService
     {
         return $this->webhooks;
+    }
+
+    public function rates(): RateService
+    {
+        return $this->rates;
+    }
+
+    public function swaps(): SwapService
+    {
+        return $this->swaps;
     }
 }

--- a/src/BlaaizClient.php
+++ b/src/BlaaizClient.php
@@ -25,7 +25,7 @@ class BlaaizClient
         'beneficiary:read', 'virtual-account:read', 'virtual-account:create', 'virtual-account:close',
         'collection:create', 'collection:crypto:create', 'collection:interac:accept',
         'payout:create', 'swap:create', 'transaction:read', 'fees:read', 'file:upload',
-        'webhook:read', 'webhook:write', 'webhook:replay',
+        'webhook:read', 'webhook:write', 'webhook:replay', 'rates:read',
     ];
 
     protected ?string $accessToken = null;
@@ -59,7 +59,7 @@ class BlaaizClient
             $this->defaultHeaders['x-blaaiz-api-key'] = $this->apiKey;
         }
 
-        $this->httpClient = new Client([
+        $this->httpClient = $this->createHttpClient([
             'base_uri' => $this->baseUrl,
             'timeout' => $this->timeout,
             'headers' => $this->defaultHeaders,
@@ -73,7 +73,7 @@ class BlaaizClient
         }
 
         try {
-            $client = new Client([
+            $client = $this->createHttpClient([
                 'base_uri' => $this->baseUrl,
                 'timeout' => $this->timeout,
             ]);
@@ -222,7 +222,7 @@ class BlaaizClient
                 $headers['Content-Disposition'] = "attachment; filename=\"{$filename}\"";
             }
 
-            $client = new Client(['timeout' => $this->timeout]);
+            $client = $this->createHttpClient(['timeout' => $this->timeout]);
 
             $response = $client->request('PUT', $presignedUrl, [
                 'headers' => $headers,
@@ -262,7 +262,7 @@ class BlaaizClient
     public function downloadFile(string $url): array
     {
         try {
-            $client = new Client(['timeout' => $this->timeout]);
+            $client = $this->createHttpClient(['timeout' => $this->timeout]);
 
             $response = $client->request('GET', $url, [
                 'headers' => [
@@ -336,5 +336,10 @@ class BlaaizClient
         $contentType = explode(';', $contentType)[0];
 
         return $mimeToExt[$contentType] ?? null;
+    }
+
+    protected function createHttpClient(array $config): Client
+    {
+        return new Client($config);
     }
 }

--- a/src/BlaaizClient.php
+++ b/src/BlaaizClient.php
@@ -9,28 +9,55 @@ use GuzzleHttp\Exception\RequestException;
 
 class BlaaizClient
 {
-    protected string $apiKey;
     protected string $baseUrl;
     protected int $timeout;
     protected Client $httpClient;
     protected array $defaultHeaders;
 
-    public function __construct(string $apiKey, array $options = [])
+    protected string $apiKey;
+    protected string $clientId;
+    protected string $clientSecret;
+    protected string $oauthScope;
+    protected bool $useOAuth;
+
+    protected const ALL_SCOPES = [
+        'wallet:read', 'currency:read', 'bank:read', 'customer:read', 'customer:write',
+        'beneficiary:read', 'virtual-account:read', 'virtual-account:create', 'virtual-account:close',
+        'collection:create', 'collection:crypto:create', 'collection:interac:accept',
+        'payout:create', 'swap:create', 'transaction:read', 'fees:read', 'file:upload',
+        'webhook:read', 'webhook:write', 'webhook:replay',
+    ];
+
+    protected ?string $accessToken = null;
+    protected ?int $tokenExpiresAt = null;
+
+    public function __construct(array $options = [])
     {
-        if (empty($apiKey)) {
-            throw new BlaaizException('API key is required');
+        $this->clientId = $options['client_id'] ?? '';
+        $this->clientSecret = $options['client_secret'] ?? '';
+        $this->oauthScope = $options['oauth_scope'] ?? implode(' ', self::ALL_SCOPES);
+        $this->apiKey = $options['api_key'] ?? '';
+
+        $this->useOAuth = !empty($this->clientId) && !empty($this->clientSecret);
+
+        if (!$this->useOAuth && empty($this->apiKey)) {
+            throw new BlaaizException(
+                'Authentication required: provide either BLAAIZ_CLIENT_ID and BLAAIZ_CLIENT_SECRET for OAuth, or BLAAIZ_API_KEY for legacy authentication'
+            );
         }
 
-        $this->apiKey = $apiKey;
         $this->baseUrl = $options['base_url'] ?? 'https://api-dev.blaaiz.com';
         $this->timeout = $options['timeout'] ?? 30;
 
         $this->defaultHeaders = [
-            'x-blaaiz-api-key' => $this->apiKey,
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
             'User-Agent' => 'Blaaiz-Laravel-SDK/1.0.0',
         ];
+
+        if (!$this->useOAuth) {
+            $this->defaultHeaders['x-blaaiz-api-key'] = $this->apiKey;
+        }
 
         $this->httpClient = new Client([
             'base_uri' => $this->baseUrl,
@@ -39,14 +66,85 @@ class BlaaizClient
         ]);
     }
 
+    protected function getOAuthToken(): string
+    {
+        if ($this->accessToken && $this->tokenExpiresAt && time() < $this->tokenExpiresAt) {
+            return $this->accessToken;
+        }
+
+        try {
+            $client = new Client([
+                'base_uri' => $this->baseUrl,
+                'timeout' => $this->timeout,
+            ]);
+
+            $response = $client->request('POST', '/oauth/token', [
+                'form_params' => [
+                    'grant_type' => 'client_credentials',
+                    'client_id' => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                    'scope' => $this->oauthScope,
+                ],
+            ]);
+
+            $body = json_decode($response->getBody()->getContents(), true);
+
+            if (json_last_error() !== JSON_ERROR_NONE || empty($body['access_token'])) {
+                throw new BlaaizException(
+                    'Failed to parse OAuth token response',
+                    $response->getStatusCode(),
+                    'OAUTH_PARSE_ERROR'
+                );
+            }
+
+            $this->accessToken = $body['access_token'];
+            // Refresh 60 seconds before expiry to avoid edge cases
+            $this->tokenExpiresAt = time() + ($body['expires_in'] ?? 900) - 60;
+
+            return $this->accessToken;
+
+        } catch (RequestException $e) {
+            $statusCode = $e->getResponse() ? $e->getResponse()->getStatusCode() : null;
+            $responseBody = $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null;
+            $errorData = $responseBody ? json_decode($responseBody, true) : null;
+
+            throw new BlaaizException(
+                $errorData['error_description'] ?? $errorData['message'] ?? 'OAuth token request failed: ' . $e->getMessage(),
+                $statusCode,
+                $errorData['error'] ?? 'OAUTH_ERROR'
+            );
+
+        } catch (GuzzleException $e) {
+            throw new BlaaizException(
+                "OAuth token request failed: {$e->getMessage()}",
+                null,
+                'OAUTH_ERROR'
+            );
+        }
+    }
+
+    protected function getAuthHeaders(): array
+    {
+        if ($this->useOAuth) {
+            $token = $this->getOAuthToken();
+            return ['Authorization' => "Bearer {$token}"];
+        }
+
+        return ['x-blaaiz-api-key' => $this->apiKey];
+    }
+
     public function makeRequest(string $method, string $endpoint, ?array $data = null, array $headers = []): array
     {
         try {
+            $requestHeaders = array_merge($this->defaultHeaders, $this->getAuthHeaders(), $headers);
+
             $options = [
-                'headers' => array_merge($this->defaultHeaders, $headers),
+                'headers' => $requestHeaders,
             ];
 
-            if ($data !== null && strtoupper($method) !== 'GET') {
+            if ($data !== null && strtoupper($method) === 'GET') {
+                $options['query'] = $data;
+            } elseif ($data !== null) {
                 $options['json'] = $data;
             }
 
@@ -99,6 +197,10 @@ class BlaaizClient
                 'GUZZLE_ERROR'
             );
         } catch (\Exception $e) {
+            if ($e instanceof BlaaizException) {
+                throw $e;
+            }
+
             throw new BlaaizException(
                 "Unexpected error: {$e->getMessage()}",
                 null,

--- a/src/BlaaizServiceProvider.php
+++ b/src/BlaaizServiceProvider.php
@@ -12,14 +12,15 @@ class BlaaizServiceProvider extends ServiceProvider
 
         $this->app->singleton('blaaiz', function ($app) {
             $config = $app['config']['blaaiz'];
-            
-            return new Blaaiz(
-                $config['api_key'] ?: 'test-key', // Use fallback for tests
-                [
-                    'base_url' => $config['base_url'],
-                    'timeout' => $config['timeout'],
-                ]
-            );
+
+            return new Blaaiz([
+                'api_key' => $config['api_key'] ?? '',
+                'client_id' => $config['client_id'] ?? '',
+                'client_secret' => $config['client_secret'] ?? '',
+                'oauth_scope' => $config['oauth_scope'] ?? '*',
+                'base_url' => $config['base_url'],
+                'timeout' => $config['timeout'],
+            ]);
         });
 
         $this->app->alias('blaaiz', Blaaiz::class);

--- a/src/Facades/Blaaiz.php
+++ b/src/Facades/Blaaiz.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Blaaiz\LaravelSdk\Services\FeesService fees()
  * @method static \Blaaiz\LaravelSdk\Services\FileService files()
  * @method static \Blaaiz\LaravelSdk\Services\WebhookService webhooks()
+ * @method static \Blaaiz\LaravelSdk\Services\RateService rates()
+ * @method static \Blaaiz\LaravelSdk\Services\SwapService swaps()
  * @method static bool testConnection()
  * @method static array createCompletePayout(array $payoutConfig)
  * @method static array createCompleteCollection(array $collectionConfig)

--- a/src/Services/RateService.php
+++ b/src/Services/RateService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Blaaiz\LaravelSdk\Services;
+
+class RateService extends BaseService
+{
+    public function list(?string $searchTerm = null): array
+    {
+        $params = [];
+
+        if ($searchTerm !== null) {
+            $params['search_term'] = $searchTerm;
+        }
+
+        return $this->client->makeRequest('GET', '/api/external/rate', $params ?: null);
+    }
+}

--- a/src/Services/SwapService.php
+++ b/src/Services/SwapService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Blaaiz\LaravelSdk\Services;
+
+class SwapService extends BaseService
+{
+    public function swap(array $data): array
+    {
+        $this->validateRequiredFields($data, [
+            'from_business_wallet_id',
+            'to_business_wallet_id',
+            'amount',
+        ]);
+
+        return $this->client->makeRequest('POST', '/api/external/swap', $data);
+    }
+}

--- a/tests/Feature/BlaaizHighLevelMethodsTest.php
+++ b/tests/Feature/BlaaizHighLevelMethodsTest.php
@@ -17,7 +17,7 @@ describe('Blaaiz high level methods', function () {
 
     it('testConnection returns true on success', function () {
         $mockClient = Mockery::mock(\Blaaiz\LaravelSdk\BlaaizClient::class);
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         // Replace the currencies service with a mock
         $mockCurrencyService = Mockery::mock(CurrencyService::class);
@@ -34,7 +34,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('testConnection returns false on error', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         // Replace the currencies service with a mock that throws exception
         $mockCurrencyService = Mockery::mock(CurrencyService::class);
@@ -51,7 +51,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('createCompletePayout full flow', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         // Mock all required services
         $mockCustomerService = Mockery::mock(CustomerService::class);
@@ -135,7 +135,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('createCompletePayout with existing customer', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         // Mock required services (no customer creation needed)
         $mockFeesService = Mockery::mock(FeesService::class);
@@ -187,7 +187,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('createCompletePayout propagates errors', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         $mockFeesService = Mockery::mock(FeesService::class);
         $mockPayoutService = Mockery::mock(PayoutService::class);
@@ -226,7 +226,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('createCompleteCollection with VBA', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         // Mock all required services
         $mockCustomerService = Mockery::mock(CustomerService::class);
@@ -304,7 +304,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('createCompleteCollection without VBA', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         $mockCustomerService = Mockery::mock(CustomerService::class);
         $mockCollectionService = Mockery::mock(CollectionService::class);
@@ -352,7 +352,7 @@ describe('Blaaiz high level methods', function () {
     });
 
     it('createCompleteCollection propagates errors', function () {
-        $sdk = new Blaaiz('key');
+        $sdk = new Blaaiz(['api_key' => 'key']);
         
         $mockCustomerService = Mockery::mock(CustomerService::class);
         $mockCollectionService = Mockery::mock(CollectionService::class);

--- a/tests/Feature/LaravelIntegrationTest.php
+++ b/tests/Feature/LaravelIntegrationTest.php
@@ -130,12 +130,15 @@ describe('Laravel Integration', function () {
             expect($blaaiz->fees)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\FeesService::class);
             expect($blaaiz->files)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\FileService::class);
             expect($blaaiz->webhooks)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\WebhookService::class);
+            expect($blaaiz->rates)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\RateService::class);
+            expect($blaaiz->swaps)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\SwapService::class);
         });
 
         it('can be bound with custom configuration', function () {
             // Bind custom instance
             app()->bind(Blaaiz::class, function () {
-                return new Blaaiz('custom-api-key', [
+                return new Blaaiz([
+                    'api_key' => 'custom-api-key',
                     'base_url' => 'https://api.custom-test.com',
                     'timeout' => 45
                 ]);

--- a/tests/Integration/BlaaizIntegrationTest.php
+++ b/tests/Integration/BlaaizIntegrationTest.php
@@ -6,25 +6,50 @@ use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
 /**
  * Integration Tests for Blaaiz Laravel SDK
  *
- * These tests require a valid API key and should be run against a test environment.
- * Set BLAAIZ_API_KEY environment variable to run these tests.
+ * These tests require valid credentials and should be run against a test environment.
+ * Set BLAAIZ_CLIENT_ID + BLAAIZ_CLIENT_SECRET (OAuth) or BLAAIZ_API_KEY (legacy) to run.
  */
 
 function getBlaaizInstance(): ?Blaaiz
 {
-    $apiKey = env('BLAAIZ_API_KEY');
-    if (!$apiKey) {
-        return null;
-    }
-    
     $baseURL = env('BLAAIZ_API_URL', 'https://api-dev.blaaiz.com');
-    return new Blaaiz($apiKey, ['base_url' => $baseURL]);
+
+    $clientId = env('BLAAIZ_CLIENT_ID');
+    $clientSecret = env('BLAAIZ_CLIENT_SECRET');
+    if ($clientId && $clientSecret) {
+        $options = [
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'base_url' => $baseURL,
+        ];
+        $scope = env('BLAAIZ_OAUTH_SCOPE');
+        if ($scope) {
+            $options['oauth_scope'] = $scope;
+        }
+        return new Blaaiz($options);
+    }
+
+    $apiKey = env('BLAAIZ_API_KEY');
+    if ($apiKey) {
+        return new Blaaiz(['api_key' => $apiKey, 'base_url' => $baseURL]);
+    }
+
+    return null;
+}
+
+function skipOnScopeError(BlaaizException $e): void
+{
+    if (str_contains($e->getMessage(), 'scope') || str_contains($e->getMessage(), 'Scope')) {
+        test()->markTestSkipped('OAuth credentials lack required scope: ' . $e->getMessage());
+    }
+
+    throw $e;
 }
 
 it('should connect to API', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
     
     $isConnected = $blaaiz->testConnection();
@@ -34,7 +59,7 @@ it('should connect to API', function () {
 it('should list currencies', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
     
     try {
@@ -53,7 +78,7 @@ it('should list currencies', function () {
 it('should list wallets', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
     
     $wallets = $blaaiz->wallets->list();
@@ -64,7 +89,7 @@ it('should list wallets', function () {
 it('should create and retrieve customer', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
 
     $customerData = [
@@ -96,7 +121,7 @@ it('should create and retrieve customer', function () {
 it('should upload a file', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
 
     // Create a test customer
@@ -132,7 +157,7 @@ it('should upload a file', function () {
 it('should verify webhook signature', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
 
     $payload = '{"transaction_id":"test-123","status":"completed"}';
@@ -151,7 +176,7 @@ it('should verify webhook signature', function () {
 it('should construct webhook event', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
 
     $payload = '{"transaction_id":"test-123","status":"completed"}';
@@ -168,7 +193,7 @@ it('should construct webhook event', function () {
 });
 
 it('should handle invalid API key gracefully', function () {
-    $invalidBlaaiz = new Blaaiz('invalid-key');
+    $invalidBlaaiz = new Blaaiz(['api_key' => 'invalid-key']);
 
     expect(fn() => $invalidBlaaiz->currencies->list())
         ->toThrow(BlaaizException::class);
@@ -177,9 +202,84 @@ it('should handle invalid API key gracefully', function () {
 it('should handle invalid customer creation', function () {
     $blaaiz = getBlaaizInstance();
     if (!$blaaiz) {
-        $this->markTestSkipped('BLAAIZ_API_KEY not set');
+        $this->markTestSkipped('No Blaaiz credentials set');
     }
 
     expect(fn() => $blaaiz->customers->create([])) // Missing required fields
+        ->toThrow(BlaaizException::class);
+});
+
+it('should list rates', function () {
+    $blaaiz = getBlaaizInstance();
+    if (!$blaaiz) {
+        $this->markTestSkipped('No Blaaiz credentials set');
+    }
+
+    $result = $blaaiz->rates->list();
+
+    expect($result)->toBeArray();
+    expect($result)->toHaveKey('data');
+    expect($result['data'])->toHaveKey('data');
+});
+
+it('should list rates with search term', function () {
+    $blaaiz = getBlaaizInstance();
+    if (!$blaaiz) {
+        $this->markTestSkipped('No Blaaiz credentials set');
+    }
+
+    $result = $blaaiz->rates->list('USD');
+
+    expect($result)->toBeArray();
+    expect($result)->toHaveKey('data');
+});
+
+it('should validate swap requires all fields', function () {
+    expect(fn() => (new Blaaiz(['api_key' => 'test']))->swaps->swap([]))
+        ->toThrow(BlaaizException::class, 'from_business_wallet_id is required');
+
+    expect(fn() => (new Blaaiz(['api_key' => 'test']))->swaps->swap([
+        'from_business_wallet_id' => 'w1',
+    ]))->toThrow(BlaaizException::class, 'to_business_wallet_id is required');
+
+    expect(fn() => (new Blaaiz(['api_key' => 'test']))->swaps->swap([
+        'from_business_wallet_id' => 'w1',
+        'to_business_wallet_id' => 'w2',
+    ]))->toThrow(BlaaizException::class, 'amount is required');
+});
+
+it('should authenticate with OAuth and list rates', function () {
+    $clientId = env('BLAAIZ_CLIENT_ID');
+    $clientSecret = env('BLAAIZ_CLIENT_SECRET');
+    if (!$clientId || !$clientSecret) {
+        $this->markTestSkipped('BLAAIZ_CLIENT_ID and BLAAIZ_CLIENT_SECRET not set');
+    }
+
+    $baseURL = env('BLAAIZ_API_URL', 'https://api-dev.blaaiz.com');
+    $options = [
+        'client_id' => $clientId,
+        'client_secret' => $clientSecret,
+        'base_url' => $baseURL,
+    ];
+    $scope = env('BLAAIZ_OAUTH_SCOPE');
+    if ($scope) {
+        $options['oauth_scope'] = $scope;
+    }
+    $blaaiz = new Blaaiz($options);
+
+    $result = $blaaiz->rates->list();
+
+    expect($result)->toBeArray();
+    expect($result)->toHaveKey('data');
+});
+
+it('should fail OAuth with invalid credentials', function () {
+    $blaaiz = new Blaaiz([
+        'client_id' => 'invalid-client-id',
+        'client_secret' => 'invalid-client-secret',
+        'base_url' => 'https://api-dev.blaaiz.com',
+    ]);
+
+    expect(fn() => $blaaiz->rates->list())
         ->toThrow(BlaaizException::class);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,13 +3,24 @@
 namespace Blaaiz\LaravelSdk\Tests;
 
 use Blaaiz\LaravelSdk\BlaaizServiceProvider;
+use Dotenv\Dotenv;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     protected function setUp(): void
     {
+        $this->loadEnvFile();
         parent::setUp();
+    }
+
+    protected function loadEnvFile(): void
+    {
+        $envPath = __DIR__ . '/..';
+        if (file_exists($envPath . '/.env')) {
+            $dotenv = Dotenv::createImmutable($envPath);
+            $dotenv->safeLoad();
+        }
     }
 
     /**

--- a/tests/Unit/BlaaizClientTest.php
+++ b/tests/Unit/BlaaizClientTest.php
@@ -3,11 +3,27 @@
 use Blaaiz\LaravelSdk\BlaaizClient;
 use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+
+function makeQueuedBlaaizClient(array $options, array $queuedClients): BlaaizClient
+{
+    return new class($options, $queuedClients) extends BlaaizClient {
+        public function __construct(array $options, private array $queuedClients)
+        {
+            parent::__construct($options);
+        }
+
+        protected function createHttpClient(array $config): Client
+        {
+            return array_shift($this->queuedClients) ?? parent::createHttpClient($config);
+        }
+    };
+}
 
 describe('BlaaizClient.makeRequest', function () {
     it('resolves on successful request', function () {
@@ -97,6 +113,64 @@ describe('BlaaizClient.makeRequest', function () {
 
         expect(fn() => $client->makeRequest('GET', '/test'))
             ->toThrow(BlaaizException::class);
+    });
+
+    it('uses non-2xx response body when http errors are disabled', function () {
+        $mockHandler = new MockHandler([
+            new Response(500, ['Content-Type' => 'application/json'], json_encode([
+                'message' => 'server exploded',
+                'code' => 'SERVER_ERROR',
+            ])),
+        ]);
+
+        $client = new Client([
+            'handler' => HandlerStack::create($mockHandler),
+            'http_errors' => false,
+        ]);
+
+        $blaaizClient = new BlaaizClient(['api_key' => 'test-key']);
+
+        $reflection = new ReflectionClass($blaaizClient);
+        $property = $reflection->getProperty('httpClient');
+        $property->setAccessible(true);
+        $property->setValue($blaaizClient, $client);
+
+        expect(fn() => $blaaizClient->makeRequest('GET', '/test'))
+            ->toThrow(BlaaizException::class, 'server exploded');
+    });
+
+    it('falls back to request exception message when response body is empty', function () {
+        $mockHandler = new MockHandler([
+            new RequestException('Connection timeout', new Request('GET', '/test'))
+        ]);
+
+        $client = new Client(['handler' => HandlerStack::create($mockHandler)]);
+        $blaaizClient = new BlaaizClient(['api_key' => 'test-key']);
+
+        $reflection = new ReflectionClass($blaaizClient);
+        $property = $reflection->getProperty('httpClient');
+        $property->setAccessible(true);
+        $property->setValue($blaaizClient, $client);
+
+        expect(fn() => $blaaizClient->makeRequest('GET', '/test'))
+            ->toThrow(BlaaizException::class, 'Connection timeout');
+    });
+
+    it('wraps unexpected exceptions from handlers', function () {
+        $handler = static function (): void {
+            throw new RuntimeException('boom');
+        };
+
+        $client = new Client(['handler' => $handler]);
+        $blaaizClient = new BlaaizClient(['api_key' => 'test-key']);
+
+        $reflection = new ReflectionClass($blaaizClient);
+        $property = $reflection->getProperty('httpClient');
+        $property->setAccessible(true);
+        $property->setValue($blaaizClient, $client);
+
+        expect(fn() => $blaaizClient->makeRequest('GET', '/test'))
+            ->toThrow(BlaaizException::class, 'Unexpected error: boom');
     });
 
     it('sends correct headers', function () {
@@ -215,51 +289,205 @@ describe('BlaaizClient constructor', function () {
 
 describe('BlaaizClient.uploadFile', function () {
     it('uploads file successfully', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        // which would require refactoring the uploadFile method
-        expect(true)->toBeTrue();
+        $uploadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, ['ETag' => '"etag-123"']),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $uploadClient,
+        ]);
+
+        $result = $client->uploadFile('https://example.com/upload', 'file-content', 'application/pdf', 'test.pdf');
+
+        expect($result)->toBe([
+            'status' => 200,
+            'etag' => '"etag-123"',
+        ]);
     });
 
     it('uploads file without content type and filename', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $uploadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, ['etag' => '"etag-456"']),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $uploadClient,
+        ]);
+
+        $result = $client->uploadFile('https://example.com/upload', 'file-content');
+
+        expect($result['etag'])->toBe('"etag-456"');
     });
 
     it('throws exception when no ETag received', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $uploadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, []),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $uploadClient,
+        ]);
+
+        expect(fn() => $client->uploadFile('https://example.com/upload', 'file-content'))
+            ->toThrow(BlaaizException::class, 'S3 upload failed: No ETag received from S3');
     });
 
-    it('handles S3 upload errors', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+    it('handles S3 upload request exceptions', function () {
+        $uploadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new RequestException(
+                    'Upload failed',
+                    new Request('PUT', 'https://example.com/upload'),
+                    new Response(403, [], 'forbidden')
+                ),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $uploadClient,
+        ]);
+
+        expect(fn() => $client->uploadFile('https://example.com/upload', 'file-content'))
+            ->toThrow(BlaaizException::class, 'S3 upload failed with status 403: forbidden');
+    });
+
+    it('handles S3 upload guzzle exceptions', function () {
+        $handler = static function (): never {
+            throw new class('Network failed') extends RuntimeException implements GuzzleException {};
+        };
+
+        $uploadClient = new Client(['handler' => $handler]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $uploadClient,
+        ]);
+
+        expect(fn() => $client->uploadFile('https://example.com/upload', 'file-content'))
+            ->toThrow(BlaaizException::class, 'S3 upload request failed: Network failed');
     });
 });
 
 describe('BlaaizClient.downloadFile', function () {
     it('downloads file successfully', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $downloadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, [
+                    'Content-Type' => 'image/jpeg',
+                    'Content-Disposition' => 'attachment; filename="passport.jpg"',
+                ], 'image-bytes'),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $downloadClient,
+        ]);
+
+        $result = $client->downloadFile('https://example.com/image.jpg');
+
+        expect($result)->toBe([
+            'content' => 'image-bytes',
+            'content_type' => 'image/jpeg',
+            'filename' => 'passport.jpg',
+        ]);
     });
 
     it('extracts filename from URL when not in headers', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $downloadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, ['Content-Type' => 'image/jpeg'], 'image-bytes'),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $downloadClient,
+        ]);
+
+        $result = $client->downloadFile('https://example.com/documents/passport.jpg');
+
+        expect($result['filename'])->toBe('passport.jpg');
     });
 
     it('adds extension when filename has none and content type is known', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $downloadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, ['Content-Type' => 'application/pdf'], 'pdf-bytes'),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $downloadClient,
+        ]);
+
+        $result = $client->downloadFile('https://example.com/download');
+
+        expect($result['filename'])->toBe('download.pdf');
     });
 
     it('handles download errors', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $downloadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new RequestException(
+                    'Not found',
+                    new Request('GET', 'https://example.com/file'),
+                    new Response(404, [], 'missing')
+                ),
+            ])),
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $downloadClient,
+        ]);
+
+        expect(fn() => $client->downloadFile('https://example.com/file'))
+            ->toThrow(BlaaizException::class, 'File download failed: Not found');
+    });
+
+    it('throws when download returns a non-success status without request exceptions', function () {
+        $downloadClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(500, ['Content-Type' => 'text/plain'], 'server-error'),
+            ])),
+            'http_errors' => false,
+        ]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $downloadClient,
+        ]);
+
+        expect(fn() => $client->downloadFile('https://example.com/file'))
+            ->toThrow(BlaaizException::class, 'Failed to download file: HTTP 500');
     });
 
     it('handles network errors', function () {
-        // This is an integration test - for unit tests we'd need to mock the client creation
-        expect(true)->toBeTrue();
+        $handler = static function (): never {
+            throw new class('DNS failed') extends RuntimeException implements GuzzleException {};
+        };
+
+        $downloadClient = new Client(['handler' => $handler]);
+
+        $client = makeQueuedBlaaizClient(['api_key' => 'test-key'], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $downloadClient,
+        ]);
+
+        expect(fn() => $client->downloadFile('https://example.com/file'))
+            ->toThrow(BlaaizException::class, 'File download failed: DNS failed');
     });
 });
 

--- a/tests/Unit/BlaaizClientTest.php
+++ b/tests/Unit/BlaaizClientTest.php
@@ -21,7 +21,7 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
@@ -46,7 +46,7 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
@@ -65,7 +65,7 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
@@ -88,7 +88,7 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
@@ -107,7 +107,7 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
@@ -131,7 +131,7 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
@@ -146,7 +146,7 @@ describe('BlaaizClient.makeRequest', function () {
         expect($requestBody)->toBe($testData);
     });
 
-    it('does not send data for GET requests', function () {
+    it('sends data as query params for GET requests', function () {
         $mockHandler = new MockHandler([
             new Response(200, ['Content-Type' => 'application/json'], json_encode(['ok' => true]))
         ]);
@@ -154,28 +154,29 @@ describe('BlaaizClient.makeRequest', function () {
         $handlerStack = HandlerStack::create($mockHandler);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $client = new BlaaizClient('test-key');
-        
+        $client = new BlaaizClient(['api_key' => 'test-key']);
+
         $reflection = new ReflectionClass($client);
         $property = $reflection->getProperty('httpClient');
         $property->setAccessible(true);
         $property->setValue($client, $httpClient);
 
-        $client->makeRequest('GET', '/test', ['should' => 'be_ignored']);
+        $client->makeRequest('GET', '/test', ['search_term' => 'USD']);
 
         $lastRequest = $mockHandler->getLastRequest();
         expect($lastRequest->getBody()->getContents())->toBe('');
+        expect($lastRequest->getUri()->getQuery())->toContain('search_term=USD');
     });
 });
 
 describe('BlaaizClient constructor', function () {
-    it('throws exception for empty API key', function () {
-        expect(fn() => new BlaaizClient(''))
-            ->toThrow(BlaaizException::class, 'API key is required');
+    it('throws exception when no auth credentials provided', function () {
+        expect(fn() => new BlaaizClient([]))
+            ->toThrow(BlaaizException::class, 'Authentication required');
     });
 
     it('sets default configuration', function () {
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
 
         $reflection = new ReflectionClass($client);
         
@@ -198,7 +199,7 @@ describe('BlaaizClient constructor', function () {
             'timeout' => 60
         ];
 
-        $client = new BlaaizClient('test-key', $options);
+        $client = new BlaaizClient(array_merge(['api_key' => 'test-key'], $options));
 
         $reflection = new ReflectionClass($client);
         
@@ -264,7 +265,7 @@ describe('BlaaizClient.downloadFile', function () {
 
 describe('BlaaizClient private methods', function () {
     it('maps content types to extensions correctly', function () {
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         $reflection = new ReflectionClass($client);
         $method = $reflection->getMethod('getExtensionFromContentType');
         $method->setAccessible(true);
@@ -277,7 +278,7 @@ describe('BlaaizClient private methods', function () {
     });
 
     it('handles content type with charset', function () {
-        $client = new BlaaizClient('test-key');
+        $client = new BlaaizClient(['api_key' => 'test-key']);
         $reflection = new ReflectionClass($client);
         $method = $reflection->getMethod('getExtensionFromContentType');
         $method->setAccessible(true);

--- a/tests/Unit/BlaaizTest.php
+++ b/tests/Unit/BlaaizTest.php
@@ -16,7 +16,7 @@ use Blaaiz\LaravelSdk\Services\WebhookService;
 
 describe('Blaaiz SDK main class', function () {
     it('creates instance with API key', function () {
-        $blaaiz = new Blaaiz('test-api-key');
+        $blaaiz = new Blaaiz(['api_key' => 'test-api-key']);
 
         expect($blaaiz)->toBeInstanceOf(Blaaiz::class);
 
@@ -35,13 +35,13 @@ describe('Blaaiz SDK main class', function () {
             'timeout' => 60
         ];
 
-        $blaaiz = new Blaaiz('test-key', $options);
+        $blaaiz = new Blaaiz(array_merge(['api_key' => 'test-key'], $options));
 
         expect($blaaiz)->toBeInstanceOf(Blaaiz::class);
     });
 
     it('initializes all service properties', function () {
-        $blaaiz = new Blaaiz('test-key');
+        $blaaiz = new Blaaiz(['api_key' => 'test-key']);
 
         expect($blaaiz->customers)->toBeInstanceOf(CustomerService::class);
         expect($blaaiz->collections)->toBeInstanceOf(CollectionService::class);
@@ -54,10 +54,12 @@ describe('Blaaiz SDK main class', function () {
         expect($blaaiz->fees)->toBeInstanceOf(FeesService::class);
         expect($blaaiz->files)->toBeInstanceOf(FileService::class);
         expect($blaaiz->webhooks)->toBeInstanceOf(WebhookService::class);
+        expect($blaaiz->rates)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\RateService::class);
+        expect($blaaiz->swaps)->toBeInstanceOf(\Blaaiz\LaravelSdk\Services\SwapService::class);
     });
 
     it('passes the same client instance to all services', function () {
-        $blaaiz = new Blaaiz('test-key');
+        $blaaiz = new Blaaiz(['api_key' => 'test-key']);
 
         // Get the client from the main SDK
         $reflection = new ReflectionClass($blaaiz);
@@ -77,7 +79,9 @@ describe('Blaaiz SDK main class', function () {
             $blaaiz->currencies,
             $blaaiz->fees,
             $blaaiz->files,
-            $blaaiz->webhooks
+            $blaaiz->webhooks,
+            $blaaiz->rates,
+            $blaaiz->swaps
         ];
 
         foreach ($services as $service) {
@@ -91,13 +95,13 @@ describe('Blaaiz SDK main class', function () {
     });
 
     it('has public service properties', function () {
-        $blaaiz = new Blaaiz('test-key');
+        $blaaiz = new Blaaiz(['api_key' => 'test-key']);
 
         $reflection = new ReflectionClass($blaaiz);
 
         $serviceProperties = [
             'customers', 'collections', 'payouts', 'wallets', 'virtualBankAccounts',
-            'transactions', 'banks', 'currencies', 'fees', 'files', 'webhooks'
+            'transactions', 'banks', 'currencies', 'fees', 'files', 'webhooks', 'rates', 'swaps'
         ];
 
         foreach ($serviceProperties as $propertyName) {
@@ -107,7 +111,7 @@ describe('Blaaiz SDK main class', function () {
     });
 
     it('has protected client property', function () {
-        $blaaiz = new Blaaiz('test-key');
+        $blaaiz = new Blaaiz(['api_key' => 'test-key']);
 
         $reflection = new ReflectionClass($blaaiz);
         $clientProperty = $reflection->getProperty('client');

--- a/tests/Unit/OAuthClientTest.php
+++ b/tests/Unit/OAuthClientTest.php
@@ -1,0 +1,215 @@
+<?php
+
+use Blaaiz\LaravelSdk\BlaaizClient;
+use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+describe('BlaaizClient OAuth', function () {
+    it('creates instance with OAuth credentials', function () {
+        $client = new BlaaizClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'oauth_scope' => '*',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+
+        $useOAuthProperty = $reflection->getProperty('useOAuth');
+        $useOAuthProperty->setAccessible(true);
+        expect($useOAuthProperty->getValue($client))->toBeTrue();
+
+        $clientIdProperty = $reflection->getProperty('clientId');
+        $clientIdProperty->setAccessible(true);
+        expect($clientIdProperty->getValue($client))->toBe('test-client-id');
+    });
+
+    it('prefers OAuth over API key when both are provided', function () {
+        $client = new BlaaizClient([
+            'api_key' => 'test-key',
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $useOAuthProperty = $reflection->getProperty('useOAuth');
+        $useOAuthProperty->setAccessible(true);
+        expect($useOAuthProperty->getValue($client))->toBeTrue();
+    });
+
+    it('falls back to API key when OAuth credentials are not provided', function () {
+        $client = new BlaaizClient(['api_key' => 'test-key']);
+
+        $reflection = new ReflectionClass($client);
+        $useOAuthProperty = $reflection->getProperty('useOAuth');
+        $useOAuthProperty->setAccessible(true);
+        expect($useOAuthProperty->getValue($client))->toBeFalse();
+    });
+
+    it('throws exception when no credentials are provided', function () {
+        expect(fn() => new BlaaizClient([]))
+            ->toThrow(BlaaizException::class, 'Authentication required');
+    });
+
+    it('throws exception when only client_id is provided without client_secret', function () {
+        expect(fn() => new BlaaizClient(['client_id' => 'test-id']))
+            ->toThrow(BlaaizException::class, 'Authentication required');
+    });
+
+    it('throws exception when only client_secret is provided without client_id', function () {
+        expect(fn() => new BlaaizClient(['client_secret' => 'test-secret']))
+            ->toThrow(BlaaizException::class, 'Authentication required');
+    });
+
+    it('does not include x-blaaiz-api-key header when using OAuth', function () {
+        $client = new BlaaizClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $headersProperty = $reflection->getProperty('defaultHeaders');
+        $headersProperty->setAccessible(true);
+        $headers = $headersProperty->getValue($client);
+
+        expect($headers)->not->toHaveKey('x-blaaiz-api-key');
+    });
+
+    it('includes x-blaaiz-api-key header when using API key', function () {
+        $client = new BlaaizClient(['api_key' => 'test-key']);
+
+        $reflection = new ReflectionClass($client);
+        $headersProperty = $reflection->getProperty('defaultHeaders');
+        $headersProperty->setAccessible(true);
+        $headers = $headersProperty->getValue($client);
+
+        expect($headers)->toHaveKey('x-blaaiz-api-key');
+        expect($headers['x-blaaiz-api-key'])->toBe('test-key');
+    });
+
+    it('fetches and caches OAuth token', function () {
+        // Create a client with OAuth credentials
+        $client = new BlaaizClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'oauth_scope' => 'wallet:read',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $method = $reflection->getMethod('getOAuthToken');
+        $method->setAccessible(true);
+
+        // Manually set a cached token to test caching
+        $tokenProperty = $reflection->getProperty('accessToken');
+        $tokenProperty->setAccessible(true);
+        $tokenProperty->setValue($client, 'cached-token');
+
+        $expiresProperty = $reflection->getProperty('tokenExpiresAt');
+        $expiresProperty->setAccessible(true);
+        $expiresProperty->setValue($client, time() + 600);
+
+        $token = $method->invoke($client);
+        expect($token)->toBe('cached-token');
+    });
+
+    it('refreshes expired OAuth token', function () {
+        $client = new BlaaizClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+
+        // Set an expired token
+        $tokenProperty = $reflection->getProperty('accessToken');
+        $tokenProperty->setAccessible(true);
+        $tokenProperty->setValue($client, 'expired-token');
+
+        $expiresProperty = $reflection->getProperty('tokenExpiresAt');
+        $expiresProperty->setAccessible(true);
+        $expiresProperty->setValue($client, time() - 1);
+
+        // The getOAuthToken method will try to fetch a new token
+        // which will fail since we haven't mocked the HTTP client for the token endpoint
+        $method = $reflection->getMethod('getOAuthToken');
+        $method->setAccessible(true);
+
+        expect(fn() => $method->invoke($client))
+            ->toThrow(BlaaizException::class);
+    });
+
+    it('sends Bearer token in Authorization header for OAuth requests', function () {
+        $client = new BlaaizClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+
+        // Set a valid cached token
+        $tokenProperty = $reflection->getProperty('accessToken');
+        $tokenProperty->setAccessible(true);
+        $tokenProperty->setValue($client, 'test-bearer-token');
+
+        $expiresProperty = $reflection->getProperty('tokenExpiresAt');
+        $expiresProperty->setAccessible(true);
+        $expiresProperty->setValue($client, time() + 600);
+
+        // Mock the HTTP client for the API request
+        $mockHandler = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['ok' => true]))
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $httpClient = new Client(['handler' => $handlerStack]);
+
+        $httpProperty = $reflection->getProperty('httpClient');
+        $httpProperty->setAccessible(true);
+        $httpProperty->setValue($client, $httpClient);
+
+        $client->makeRequest('GET', '/test');
+
+        $lastRequest = $mockHandler->getLastRequest();
+        expect($lastRequest->hasHeader('Authorization'))->toBeTrue();
+        expect($lastRequest->getHeader('Authorization')[0])->toBe('Bearer test-bearer-token');
+        expect($lastRequest->hasHeader('x-blaaiz-api-key'))->toBeFalse();
+    });
+
+    it('sends API key header for legacy auth requests', function () {
+        $mockHandler = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['ok' => true]))
+        ]);
+        $handlerStack = HandlerStack::create($mockHandler);
+        $httpClient = new Client(['handler' => $handlerStack]);
+
+        $client = new BlaaizClient(['api_key' => 'test-key']);
+
+        $reflection = new ReflectionClass($client);
+        $httpProperty = $reflection->getProperty('httpClient');
+        $httpProperty->setAccessible(true);
+        $httpProperty->setValue($client, $httpClient);
+
+        $client->makeRequest('GET', '/test');
+
+        $lastRequest = $mockHandler->getLastRequest();
+        expect($lastRequest->hasHeader('x-blaaiz-api-key'))->toBeTrue();
+        expect($lastRequest->getHeader('x-blaaiz-api-key')[0])->toBe('test-key');
+        expect($lastRequest->hasHeader('Authorization'))->toBeFalse();
+    });
+
+    it('defaults to all scopes when not specified', function () {
+        $client = new BlaaizClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $scopeProperty = $reflection->getProperty('oauthScope');
+        $scopeProperty->setAccessible(true);
+        $scope = $scopeProperty->getValue($client);
+        expect($scope)->toContain('wallet:read');
+        expect($scope)->toContain('swap:create');
+        expect($scope)->toContain('payout:create');
+    });
+});

--- a/tests/Unit/OAuthClientTest.php
+++ b/tests/Unit/OAuthClientTest.php
@@ -3,9 +3,27 @@
 use Blaaiz\LaravelSdk\BlaaizClient;
 use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+
+function makeQueuedOAuthClient(array $options, array $queuedClients): BlaaizClient
+{
+    return new class($options, $queuedClients) extends BlaaizClient {
+        public function __construct(array $options, private array $queuedClients)
+        {
+            parent::__construct($options);
+        }
+
+        protected function createHttpClient(array $config): Client
+        {
+            return array_shift($this->queuedClients) ?? parent::createHttpClient($config);
+        }
+    };
+}
 
 describe('BlaaizClient OAuth', function () {
     it('creates instance with OAuth credentials', function () {
@@ -211,5 +229,81 @@ describe('BlaaizClient OAuth', function () {
         expect($scope)->toContain('wallet:read');
         expect($scope)->toContain('swap:create');
         expect($scope)->toContain('payout:create');
+    });
+
+    it('throws a parse error when oauth token response is invalid', function () {
+        $tokenClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new Response(200, ['Content-Type' => 'application/json'], 'not-json'),
+            ])),
+        ]);
+
+        $client = makeQueuedOAuthClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $tokenClient,
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $method = $reflection->getMethod('getOAuthToken');
+        $method->setAccessible(true);
+
+        expect(fn() => $method->invoke($client))
+            ->toThrow(BlaaizException::class, 'Failed to parse OAuth token response');
+    });
+
+    it('uses oauth error_description from request exceptions', function () {
+        $tokenClient = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new RequestException(
+                    'Unauthorized',
+                    new Request('POST', '/oauth/token'),
+                    new Response(401, ['Content-Type' => 'application/json'], json_encode([
+                        'error' => 'invalid_client',
+                        'error_description' => 'Invalid client credentials',
+                    ]))
+                ),
+            ])),
+        ]);
+
+        $client = makeQueuedOAuthClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $tokenClient,
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $method = $reflection->getMethod('getOAuthToken');
+        $method->setAccessible(true);
+
+        expect(fn() => $method->invoke($client))
+            ->toThrow(BlaaizException::class, 'Invalid client credentials');
+    });
+
+    it('wraps guzzle exceptions when fetching oauth tokens', function () {
+        $handler = static function (): never {
+            throw new class('Token endpoint unreachable') extends RuntimeException implements GuzzleException {};
+        };
+
+        $tokenClient = new Client(['handler' => $handler]);
+
+        $client = makeQueuedOAuthClient([
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+        ], [
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            $tokenClient,
+        ]);
+
+        $reflection = new ReflectionClass($client);
+        $method = $reflection->getMethod('getOAuthToken');
+        $method->setAccessible(true);
+
+        expect(fn() => $method->invoke($client))
+            ->toThrow(BlaaizException::class, 'OAuth token request failed: Token endpoint unreachable');
     });
 });

--- a/tests/Unit/Services/AllServicesTest.php
+++ b/tests/Unit/Services/AllServicesTest.php
@@ -10,7 +10,6 @@ use Blaaiz\LaravelSdk\Services\FeesService;
 use Blaaiz\LaravelSdk\Services\FileService;
 use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
 use Blaaiz\LaravelSdk\BlaaizClient;
-use Mockery;
 
 describe('CollectionService', function () {
     beforeEach(function () {
@@ -58,6 +57,24 @@ describe('CollectionService', function () {
         expect($result)->toBe(['data' => ['id' => 'collection-123']]);
     });
 
+    it('calls makeRequest for initiateCrypto', function () {
+        $cryptoData = [
+            'amount' => 100,
+            'network' => 'ethereum',
+            'token' => 'USDT',
+            'wallet_id' => 'w1',
+        ];
+
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('POST', '/api/external/collection/crypto', $cryptoData)
+            ->andReturn(['data' => ['address' => '0x123']]);
+
+        $result = $this->service->initiateCrypto($cryptoData);
+        expect($result)->toBe(['data' => ['address' => '0x123']]);
+    });
+
     it('validates customer_id for attachCustomer', function () {
         expect(fn() => $this->service->attachCustomer([]))
             ->toThrow(BlaaizException::class, 'customer_id is required');
@@ -77,6 +94,17 @@ describe('CollectionService', function () {
 
         $result = $this->service->attachCustomer($attachData);
         expect($result)->toBe(['data' => ['success' => true]]);
+    });
+
+    it('calls makeRequest for getCryptoNetworks', function () {
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('GET', '/api/external/collection/crypto/networks')
+            ->andReturn(['data' => ['ethereum', 'tron']]);
+
+        $result = $this->service->getCryptoNetworks();
+        expect($result)->toBe(['data' => ['ethereum', 'tron']]);
     });
 
     it('validates required fields for acceptInteracMoneyRequest', function () {

--- a/tests/Unit/Services/CustomerServiceTest.php
+++ b/tests/Unit/Services/CustomerServiceTest.php
@@ -3,7 +3,6 @@
 use Blaaiz\LaravelSdk\Services\CustomerService;
 use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
 use Blaaiz\LaravelSdk\BlaaizClient;
-use Mockery;
 
 describe('CustomerService', function () {
     beforeEach(function () {
@@ -519,4 +518,3 @@ describe('CustomerService', function () {
         expect($result)->toBe(['data' => ['id' => $beneficiaryId, 'name' => 'John Doe']]);
     });
 });
-

--- a/tests/Unit/Services/RateServiceTest.php
+++ b/tests/Unit/Services/RateServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Blaaiz\LaravelSdk\BlaaizClient;
+use Blaaiz\LaravelSdk\Services\RateService;
+use Mockery;
+
+describe('RateService', function () {
+    beforeEach(function () {
+        $this->mockClient = Mockery::mock(BlaaizClient::class);
+        $this->service = new RateService($this->mockClient);
+    });
+
+    afterEach(function () {
+        Mockery::close();
+    });
+
+    it('calls makeRequest for list without search term', function () {
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('GET', '/api/external/rate', null)
+            ->andReturn(['data' => ['data' => []]]);
+
+        $result = $this->service->list();
+        expect($result)->toBe(['data' => ['data' => []]]);
+    });
+
+    it('calls makeRequest for list with search term', function () {
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('GET', '/api/external/rate', ['search_term' => 'USD'])
+            ->andReturn(['data' => ['data' => [['pair' => 'USD/NGN', 'value' => '1600']]]]);
+
+        $result = $this->service->list('USD');
+        expect($result)->toBe(['data' => ['data' => [['pair' => 'USD/NGN', 'value' => '1600']]]]);
+    });
+});

--- a/tests/Unit/Services/SwapServiceTest.php
+++ b/tests/Unit/Services/SwapServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Blaaiz\LaravelSdk\BlaaizClient;
+use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
+use Blaaiz\LaravelSdk\Services\SwapService;
+use Mockery;
+
+describe('SwapService', function () {
+    beforeEach(function () {
+        $this->mockClient = Mockery::mock(BlaaizClient::class);
+        $this->service = new SwapService($this->mockClient);
+    });
+
+    afterEach(function () {
+        Mockery::close();
+    });
+
+    it('validates required fields for swap', function () {
+        expect(fn() => $this->service->swap([]))
+            ->toThrow(BlaaizException::class, 'from_business_wallet_id is required');
+
+        expect(fn() => $this->service->swap(['from_business_wallet_id' => 'w1']))
+            ->toThrow(BlaaizException::class, 'to_business_wallet_id is required');
+
+        expect(fn() => $this->service->swap([
+            'from_business_wallet_id' => 'w1',
+            'to_business_wallet_id' => 'w2',
+        ]))->toThrow(BlaaizException::class, 'amount is required');
+    });
+
+    it('calls makeRequest for swap', function () {
+        $swapData = [
+            'from_business_wallet_id' => 'w1',
+            'to_business_wallet_id' => 'w2',
+            'amount' => 100,
+            'amount_type' => 'from',
+        ];
+
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('POST', '/api/external/swap', $swapData)
+            ->andReturn(['data' => ['message' => 'Money swap successful!']]);
+
+        $result = $this->service->swap($swapData);
+        expect($result)->toBe(['data' => ['message' => 'Money swap successful!']]);
+    });
+
+    it('calls makeRequest for swap with amount_type to', function () {
+        $swapData = [
+            'from_business_wallet_id' => 'w1',
+            'to_business_wallet_id' => 'w2',
+            'amount' => 160000,
+            'amount_type' => 'to',
+        ];
+
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('POST', '/api/external/swap', $swapData)
+            ->andReturn(['data' => ['message' => 'Money swap successful!']]);
+
+        $result = $this->service->swap($swapData);
+        expect($result)->toBe(['data' => ['message' => 'Money swap successful!']]);
+    });
+});

--- a/tests/Unit/Services/WebhookServiceTest.php
+++ b/tests/Unit/Services/WebhookServiceTest.php
@@ -4,7 +4,6 @@ use Blaaiz\LaravelSdk\Services\WebhookService;
 use Blaaiz\LaravelSdk\Exceptions\BlaaizException;
 use Blaaiz\LaravelSdk\BlaaizClient;
 use Carbon\Carbon;
-use Mockery;
 
 describe('WebhookService', function () {
     beforeEach(function () {


### PR DESCRIPTION
## Summary

- **OAuth 2.0 Client Credentials Authentication**: The SDK now supports OAuth as the primary authentication method. When `BLAAIZ_CLIENT_ID` and `BLAAIZ_CLIENT_SECRET` are configured, the SDK automatically obtains and caches Bearer tokens via the `/oauth/token` endpoint, refreshing them before expiry. Falls back to legacy `BLAAIZ_API_KEY` when OAuth credentials are not present.

- **Rate Service** (`GET /api/external/rate`): New `RateService` to list exchange rates, with optional `search_term` filtering (e.g., `$blaaiz->rates->list('USD')`).

- **Swap Service** (`POST /api/external/swap`): New `SwapService` to swap money between business wallets with required field validation (`from_business_wallet_id`, `to_business_wallet_id`, `amount`).

## Changes

### Core
- `BlaaizClient` constructor changed from `(string $apiKey, array $options)` to `(array $options)` to support dual auth
- Added OAuth token fetching with automatic caching and refresh (60s before expiry)
- GET requests now properly pass data as query parameters
- Added `ALL_SCOPES` constant with all 20 valid Blaaiz API scopes as default when no scope is specified

### New Services
- `src/Services/RateService.php` — List rates with optional search
- `src/Services/SwapService.php` — Swap between wallets with validation

### Configuration
- Added `client_id`, `client_secret`, `oauth_scope` to `config/blaaiz.php`
- Updated `BlaaizServiceProvider` to pass OAuth config to client

### Tests (all 175 passing, 509 assertions)
- **Unit**: 13 new OAuth tests (credential selection, token caching, Bearer vs API key headers, scope defaults, error handling)
- **Unit**: 2 Rate service tests, 3 Swap service tests
- **Integration**: OAuth authentication test, rates listing, swap validation, invalid credential handling
- Updated all existing tests for new constructor signature

### Documentation
- Updated README with OAuth as primary auth method, Rate and Swap API usage examples, and new environment variables

## Test plan
- [x] All 175 unit/feature/integration tests pass locally
- [x] OAuth authentication works against dev API
- [x] Legacy API key fallback still works
- [x] Rate listing with and without search term works
- [x] Swap validation rejects missing required fields