### PR TITLE
Add support for identity_back file category in KYC uploads

### DIFF
--- a/docs/customers.md
+++ b/docs/customers.md
@@ -58,6 +58,7 @@ $association = $blaaiz->customers()->uploadFiles('customer-id', [
 Common file keys:
 
 - `id_file`
+- `id_file_back`
 - `proof_of_address_file`
 - `liveness_check_file`
 
@@ -77,6 +78,7 @@ Required fields:
 Allowed `file_category` values:
 
 - `identity`
+- `identity_back`
 - `proof_of_address`
 - `liveness_check`
 

--- a/examples/Http/Controllers/UploadKycController.php
+++ b/examples/Http/Controllers/UploadKycController.php
@@ -12,7 +12,7 @@ class UploadKycController extends Controller
     {
         $validated = $request->validate([
             'file' => ['required', 'file'],
-            'file_category' => ['required', 'in:identity,proof_of_address,liveness_check'],
+            'file_category' => ['required', 'in:identity,identity_back,proof_of_address,liveness_check'],
         ]);
 
         $result = Blaaiz::customers()->uploadFileComplete($customerId, [

--- a/examples/Http/Controllers/UploadKycFromS3Controller.php
+++ b/examples/Http/Controllers/UploadKycFromS3Controller.php
@@ -13,7 +13,7 @@ class UploadKycFromS3Controller extends Controller
     {
         $validated = $request->validate([
             'path' => ['required', 'string'],
-            'file_category' => ['required', 'in:identity,proof_of_address,liveness_check'],
+            'file_category' => ['required', 'in:identity,identity_back,proof_of_address,liveness_check'],
         ]);
 
         $disk = Storage::disk('s3');

--- a/src/Services/CustomerService.php
+++ b/src/Services/CustomerService.php
@@ -90,8 +90,8 @@ class CustomerService extends BaseService
             throw new BlaaizException('file_category is required');
         }
 
-        if (!in_array($fileCategory, ['identity', 'proof_of_address', 'liveness_check'])) {
-            throw new BlaaizException('file_category must be one of: identity, proof_of_address, liveness_check');
+        if (!in_array($fileCategory, ['identity', 'identity_back', 'proof_of_address', 'liveness_check'])) {
+            throw new BlaaizException('file_category must be one of: identity, identity_back, proof_of_address, liveness_check');
         }
 
         try {
@@ -132,6 +132,7 @@ class CustomerService extends BaseService
 
             $fileFieldMapping = [
                 'identity' => 'id_file',
+                'identity_back' => 'id_file_back',
                 'liveness_check' => 'liveness_check_file',
                 'proof_of_address' => 'proof_of_address_file',
             ];

--- a/tests/Unit/Services/CustomerServiceTest.php
+++ b/tests/Unit/Services/CustomerServiceTest.php
@@ -211,7 +211,7 @@ describe('CustomerService', function () {
         expect(fn() => $this->service->uploadFileComplete('customer-123', [
             'file' => 'content',
             'file_category' => 'invalid'
-        ]))->toThrow(BlaaizException::class, 'file_category must be one of: identity, proof_of_address, liveness_check');
+        ]))->toThrow(BlaaizException::class, 'file_category must be one of: identity, identity_back, proof_of_address, liveness_check');
     });
 
     it('successfully uploads a file with Buffer content for uploadFileComplete', function () {
@@ -446,6 +446,7 @@ describe('CustomerService', function () {
     it('handles different file categories for uploadFileComplete', function () {
         $categories = [
             'identity' => 'id_file',
+            'identity_back' => 'id_file_back',
             'liveness_check' => 'liveness_check_file',
             'proof_of_address' => 'proof_of_address_file'
         ];


### PR DESCRIPTION
# Pull Request

## Description
Add support for the `identity_back` file category to the customer KYC file upload functionality. This allows users to upload the back side of identity documents separately from the front side.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made
- [x] Added `identity_back` to the list of allowed file categories in `CustomerService::uploadFileComplete()`
- [x] Added mapping for `identity_back` category to `id_file_back` field
- [x] Updated validation rules in example KYC upload controllers to include `identity_back`
- [x] Updated unit tests to reflect the new allowed category
- [x] Updated documentation to list the new file category and field

## Testing
- [x] Updated unit test for invalid file category validation to include `identity_back` in the error message
- [x] Updated unit test for file category mapping to include the new `identity_back` => `id_file_back` mapping
- [x] All existing tests pass with the new category added

## Code Quality
- [x] Code follows the project's coding standards
- [x] Changes are consistent across service, tests, documentation, and examples
- [x] Proper error handling maintained

## Breaking Changes
None. This is a backward-compatible addition that extends the allowed file categories without modifying existing behavior.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Changes are consistent across all affected files (service, tests, docs, examples)

https://claude.ai/code/session_013xmwoABoCXdLuZSgdYiAiV