### PR TITLE
Support filters and opt-in pagination on customers()->list()

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ $customer = Blaaiz::customers()->create([
 ]);
 ```
 
+### List customers (with optional filters and pagination)
+
+```php
+$customers = Blaaiz::customers()->list();
+
+// With filters. Supported keys: email, id_number, registration_number,
+// verification_status, type. Set `paginate => true` to receive a paginated
+// response that includes `links` and `meta` (current_page, total, ...).
+$verified = Blaaiz::customers()->list([
+    'email' => 'john@example.com',
+    'verification_status' => 'VERIFIED',
+    'type' => 'individual',
+    'paginate' => true,
+]);
+```
+
 ### Initiate a payout
 
 ```php

--- a/src/Services/CustomerService.php
+++ b/src/Services/CustomerService.php
@@ -26,9 +26,21 @@ class CustomerService extends BaseService
         return $this->client->makeRequest('POST', '/api/external/customer', $customerData);
     }
 
-    public function list(): array
+    public function list(array $filters = []): array
     {
-        return $this->client->makeRequest('GET', '/api/external/customer');
+        $query = [];
+        foreach ($filters as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+            if (is_bool($value)) {
+                $query[$key] = $value ? 'true' : 'false';
+            } else {
+                $query[$key] = $value;
+            }
+        }
+
+        return $this->client->makeRequest('GET', '/api/external/customer', $query ?: null);
     }
 
     public function get(string $customerId): array

--- a/tests/Unit/Services/CustomerServiceTest.php
+++ b/tests/Unit/Services/CustomerServiceTest.php
@@ -105,12 +105,34 @@ describe('CustomerService', function () {
         $this->mockClient
             ->shouldReceive('makeRequest')
             ->once()
-            ->with('GET', '/api/external/customer')
+            ->with('GET', '/api/external/customer', null)
             ->andReturn(['data' => []]);
 
         $result = $this->service->list();
 
         expect($result)->toBe(['data' => []]);
+    });
+
+    it('forwards filters as query parameters for list', function () {
+        $this->mockClient
+            ->shouldReceive('makeRequest')
+            ->once()
+            ->with('GET', '/api/external/customer', [
+                'email' => 'john@example.com',
+                'verification_status' => 'VERIFIED',
+                'type' => 'individual',
+                'paginate' => 'true',
+            ])
+            ->andReturn(['data' => [], 'meta' => ['current_page' => 1]]);
+
+        $result = $this->service->list([
+            'email' => 'john@example.com',
+            'verification_status' => 'VERIFIED',
+            'type' => 'individual',
+            'paginate' => true,
+        ]);
+
+        expect($result)->toBe(['data' => [], 'meta' => ['current_page' => 1]]);
     });
 
     it('throws exception for empty customer ID in get', function () {


### PR DESCRIPTION
## Summary

Mirrors the API change in [78-Financials/blaiz-api#3495](https://github.com/78-Financials/blaiz-api/pull/3495) on the `GET /api/external/customer` endpoint.

- `customers()->list()` now accepts an optional `array $filters` argument. Supported keys: `email`, `id_number`, `registration_number`, `verification_status`, `type`, `paginate` (plus `page` / `per_page` pass through).
- Filters are forwarded as the request `$data` payload; `BlaaizClient::makeRequest` already routes data on GET requests to Guzzle's `query` option. Booleans become `"true"` / `"false"`.
- When `paginate => true`, callers receive a paginated payload with `links` and `meta` (`current_page`, `total`, ...) alongside `data`.
- Backward compatible: calling `list()` with no arguments behaves exactly as before.

## Test plan

- [x] `./vendor/bin/pest tests/Unit/Services/CustomerServiceTest.php` — 32/32 passing, including the updated no-args assertion and the new filtered-query case.
- [ ] Manual smoke test against staging API with `paginate => true` filters.